### PR TITLE
Bug fix related to the RPC hit 'phi_loc_deg'

### DIFF
--- a/L1TMuonEndCap/interface/EMTFTrackTools.hh
+++ b/L1TMuonEndCap/interface/EMTFTrackTools.hh
@@ -130,12 +130,16 @@ namespace L1TMuonEndCap {
   //  return deg_to_rad(calc_phi_loc_deg_corr(bits, endcap));
   //}
 
-  inline int    calc_phi_loc_int(double glob, int sector) {  // glob in deg, sector [1-6]
+  inline double calc_phi_loc_deg_from_glob(double glob, int sector) {  // glob in deg, sector [1-6]
     // Put phi in [-180,180] range
     while (glob <  -180.)  glob += 360.;
     while (glob >= +180.)  glob -= 360.;
-
     double loc = glob - 15. - (60. * (sector-1));
+    return loc;
+  }
+
+  inline int    calc_phi_loc_int(double glob, int sector) {  // glob in deg, sector [1-6]
+    double loc = calc_phi_loc_deg_from_glob(glob, sector);
     loc = ((loc + 22.) < 0.) ? loc + 360. : loc;
     loc = (loc + 22.) * 60.;
     int phi_int = static_cast<int>(std::round(loc));

--- a/L1TMuonEndCap/src/EMTFPrimitiveConversion.cc
+++ b/L1TMuonEndCap/src/EMTFPrimitiveConversion.cc
@@ -182,6 +182,22 @@ void EMTFPrimitiveConversion::convert_csc(
   conv_hit.bend        = tp_data.bend;
 
   convert_csc_details(conv_hit);
+
+  // Add coordinates from fullsim
+  {
+    namespace l1t = L1TMuonEndCap;
+
+    const GlobalPoint& gp = tp_geom_->getGlobalPoint(muon_primitive);
+    double glob_phi   = l1t::rad_to_deg(gp.phi().value());
+    double glob_theta = l1t::rad_to_deg(gp.theta());
+    double glob_eta   = gp.eta();
+    double loc_phi    = l1t::calc_phi_loc_deg_from_glob(glob_phi, sector_);
+
+    conv_hit.phi_glob_deg = glob_phi;
+    conv_hit.phi_loc_deg  = loc_phi;
+    conv_hit.theta_deg    = glob_theta;
+    conv_hit.eta          = glob_eta;
+  }
 }
 
 void EMTFPrimitiveConversion::convert_csc_details(EMTFHitExtra& conv_hit) const {
@@ -566,15 +582,10 @@ void EMTFPrimitiveConversion::convert_rpc(
     namespace l1t = L1TMuonEndCap;
 
     const GlobalPoint& gp = tp_geom_->getGlobalPoint(muon_primitive);
-    double glob_phi   = gp.phi().value();
-    double glob_theta = gp.theta();
+    double glob_phi   = l1t::rad_to_deg(gp.phi().value());
+    double glob_theta = l1t::rad_to_deg(gp.theta());
     double glob_eta   = gp.eta();
-    glob_phi          = l1t::rad_to_deg(glob_phi);
-    glob_theta        = l1t::rad_to_deg(glob_theta);
-
-    double loc_phi = glob_phi - 15. - (60. * (sector_-1));  // assume glob_phi in [-180,180] range
-    loc_phi = ((loc_phi + 22.) < 0.) ? loc_phi + 360. : loc_phi;
-    loc_phi = (loc_phi + 22.) * 60.;
+    double loc_phi    = l1t::calc_phi_loc_deg_from_glob(glob_phi, sector_);
 
     int phi_loc_int   = l1t::calc_phi_loc_int(glob_phi, sector_);
     int theta_int     = l1t::calc_theta_int(glob_theta, endcap_);


### PR DESCRIPTION
I screwed up the RPC hit 'phi_loc_deg' calculation. This PR fixes it. 

Additionally, it also computes CSC hit 'phi_glob_deg', 'phi_loc_deg', 'theta_deg', 'eta'