### PR TITLE
Fix data-emulator agreement

### DIFF
--- a/L1TMuonEndCap/BuildFile.xml
+++ b/L1TMuonEndCap/BuildFile.xml
@@ -17,6 +17,8 @@
 <use name="Geometry/CSCGeometry"/>
 <use name="L1Trigger/DTUtilities"/>
 <use name="L1Trigger/CSCCommonTrigger"/>
+<use name="MagneticField/Engine"/>
+<use name="MagneticField/Records"/>
 
 <use name="DataFormatsSep2016/L1TMuon"/>
 

--- a/L1TMuonEndCap/interface/EMTFAngleCalculation.hh
+++ b/L1TMuonEndCap/interface/EMTFAngleCalculation.hh
@@ -9,7 +9,8 @@ public:
   void configure(
       int verbose, int endcap, int sector, int bx,
       int bxWindow,
-      int thetaWindow, int thetaWindowRPC
+      int thetaWindow, int thetaWindowRPC,
+      bool bugME11Dupes
   );
 
   void process(
@@ -27,6 +28,7 @@ private:
 
   int bxWindow_;
   int thetaWindow_, thetaWindowRPC_;
+  bool bugME11Dupes_;
 };
 
 #endif

--- a/L1TMuonEndCap/interface/EMTFBestTrackSelection.hh
+++ b/L1TMuonEndCap/interface/EMTFBestTrackSelection.hh
@@ -9,7 +9,8 @@ public:
   void configure(
       int verbose, int endcap, int sector, int bx,
       int bxWindow,
-      int maxRoadsPerZone, int maxTracks, bool useSecondEarliest
+      int maxRoadsPerZone, int maxTracks, bool useSecondEarliest,
+      bool bugSameSectorPt0
   );
 
   void process(
@@ -33,6 +34,7 @@ private:
   int bxWindow_;
   int maxRoadsPerZone_, maxTracks_;
   bool useSecondEarliest_;
+  bool bugSameSectorPt0_;
 };
 
 #endif

--- a/L1TMuonEndCap/interface/EMTFPrimitiveConversion.hh
+++ b/L1TMuonEndCap/interface/EMTFPrimitiveConversion.hh
@@ -14,7 +14,8 @@ public:
       int verbose, int endcap, int sector, int bx,
       int bxShiftCSC, int bxShiftRPC,
       const std::vector<int>& zoneBoundaries, int zoneOverlap, int zoneOverlapRPC,
-      bool duplicateTheta, bool fixZonePhi, bool useNewZones, bool fixME11Edges
+      bool duplicateTheta, bool fixZonePhi, bool useNewZones, bool fixME11Edges,
+      bool bugME11Dupes
   );
 
   template<typename T>
@@ -54,6 +55,7 @@ private:
   std::vector<int> zoneBoundaries_;
   int zoneOverlap_, zoneOverlapRPC_;
   bool duplicateTheta_, fixZonePhi_, useNewZones_, fixME11Edges_;
+  bool bugME11Dupes_;
 };
 
 #endif

--- a/L1TMuonEndCap/interface/EMTFPrimitiveMatching.hh
+++ b/L1TMuonEndCap/interface/EMTFPrimitiveMatching.hh
@@ -21,7 +21,7 @@ public:
   ) const;
 
   void process_single_zone_station(
-      int station,
+      int zone, int station,
       const EMTFRoadExtraCollection& roads,
       const EMTFHitExtraCollection& conv_hits,
       std::vector<hit_sort_pair_t>& phi_differences

--- a/L1TMuonEndCap/interface/EMTFPrimitiveMatching.hh
+++ b/L1TMuonEndCap/interface/EMTFPrimitiveMatching.hh
@@ -11,7 +11,8 @@ public:
 
   void configure(
       int verbose, int endcap, int sector, int bx,
-      bool fixZonePhi
+      bool fixZonePhi,
+      bool bugME11Dupes
   );
 
   void process(
@@ -36,6 +37,7 @@ private:
   int verbose_, endcap_, sector_, bx_;
 
   bool fixZonePhi_;
+  bool bugME11Dupes_;
 };
 
 #endif

--- a/L1TMuonEndCap/interface/EMTFPrimitiveMatching.hh
+++ b/L1TMuonEndCap/interface/EMTFPrimitiveMatching.hh
@@ -11,7 +11,7 @@ public:
 
   void configure(
       int verbose, int endcap, int sector, int bx,
-      bool fixZonePhi,
+      bool fixZonePhi, bool useNewZones,
       bool bugME11Dupes
   );
 
@@ -36,7 +36,7 @@ public:
 private:
   int verbose_, endcap_, sector_, bx_;
 
-  bool fixZonePhi_;
+  bool fixZonePhi_, useNewZones_;
   bool bugME11Dupes_;
 };
 

--- a/L1TMuonEndCap/interface/EMTFPrimitiveMatching.hh
+++ b/L1TMuonEndCap/interface/EMTFPrimitiveMatching.hh
@@ -27,10 +27,6 @@ public:
       std::vector<hit_sort_pair_t>& phi_differences
   ) const;
 
-  void sort_ph_diff(
-      std::vector<hit_sort_pair_t>& phi_differences
-  ) const;
-
   void insert_hits(
       hit_ptr_t conv_hit_ptr, const EMTFHitExtraCollection& conv_hits,
       EMTFTrackExtra& track

--- a/L1TMuonEndCap/interface/EMTFPrimitiveSelection.hh
+++ b/L1TMuonEndCap/interface/EMTFPrimitiveSelection.hh
@@ -9,7 +9,8 @@ public:
   void configure(
       int verbose, int endcap, int sector, int bx,
       int bxShiftCSC, int bxShiftRPC,
-      bool includeNeighbor, bool duplicateTheta
+      bool includeNeighbor, bool duplicateTheta,
+      bool bugME11Dupes
   );
 
   template<typename T>
@@ -51,6 +52,8 @@ private:
   int bxShiftCSC_, bxShiftRPC_;
 
   bool includeNeighbor_, duplicateTheta_;
+
+  bool bugME11Dupes_;
 };
 
 #endif

--- a/L1TMuonEndCap/interface/EMTFSectorProcessor.hh
+++ b/L1TMuonEndCap/interface/EMTFSectorProcessor.hh
@@ -36,8 +36,9 @@ public:
       int minBX, int maxBX, int bxWindow, int bxShiftCSC, int bxShiftRPC,
       const std::vector<int>& zoneBoundaries, int zoneOverlap, int zoneOverlapRPC,
       bool includeNeighbor, bool duplicateTheta, bool fixZonePhi, bool useNewZones, bool fixME11Edges,
-      const std::vector<std::string>& pattDefinitions, const std::vector<std::string>& symPattDefinitions, int thetaWindow, int thetaWindowRPC, bool useSymPatterns,
-      int maxRoadsPerZone, int maxTracks, bool useSecondEarliest,
+      const std::vector<std::string>& pattDefinitions, const std::vector<std::string>& symPattDefinitions, bool useSymPatterns,
+      int thetaWindow, int thetaWindowRPC, bool bugME11Dupes,
+      int maxRoadsPerZone, int maxTracks, bool useSecondEarliest, bool bugSameSectorPt0,
       bool readPtLUTFile, bool fixMode15HighPt, bool bug9BitDPhi, bool bugMode7CLCT, bool bugNegPt, bool bugGMTPhi
   );
 
@@ -81,12 +82,16 @@ private:
 
   // For pattern recognition
   std::vector<std::string> pattDefinitions_, symPattDefinitions_;
-  int thetaWindow_, thetaWindowRPC_;
   bool useSymPatterns_;
+
+  // For track building
+  int thetaWindow_, thetaWindowRPC_;
+  bool bugME11Dupes_;
 
   // For ghost cancellation
   int maxRoadsPerZone_, maxTracks_;
   bool useSecondEarliest_;
+  bool bugSameSectorPt0_;
 
   // For pt assignment
   bool readPtLUTFile_, fixMode15HighPt_;

--- a/L1TMuonEndCap/interface/GeometryTranslator.h
+++ b/L1TMuonEndCap/interface/GeometryTranslator.h
@@ -29,6 +29,7 @@ class RPCGeometry;
 class CSCGeometry;
 class CSCLayer;
 class DTGeometry;
+class MagneticField;
 
 namespace L1TMuonEndCap {
   class TriggerPrimitive;
@@ -46,12 +47,21 @@ namespace L1TMuonEndCap {
 
     void checkAndUpdateGeometry(const edm::EventSetup&);
 
+    const RPCGeometry& getRPCGeometry() const { return *_georpc; }
+    const CSCGeometry& getCSCGeometry() const { return *_geocsc; }
+    const DTGeometry&  getDTGeometry()  const { return *_geodt;  }
+
+    const MagneticField& getMagneticField() const { return *_magfield; }
+
   private:
     // pointers to the current geometry records
     unsigned long long _geom_cache_id;
     edm::ESHandle<RPCGeometry> _georpc;
     edm::ESHandle<CSCGeometry> _geocsc;
     edm::ESHandle<DTGeometry>  _geodt;
+
+    unsigned long long _magfield_cache_id;
+    edm::ESHandle<MagneticField> _magfield;
 
     GlobalPoint getRPCSpecificPoint(const TriggerPrimitive&) const;
     double calcRPCSpecificEta(const TriggerPrimitive&) const;

--- a/L1TMuonEndCap/plugins/DummyL1TMuonEndCapTrackProducer.cc
+++ b/L1TMuonEndCap/plugins/DummyL1TMuonEndCapTrackProducer.cc
@@ -1,0 +1,97 @@
+#include "DummyL1TMuonEndCapTrackProducer.h"
+
+
+DummyL1TMuonEndCapTrackProducerSep2016::DummyL1TMuonEndCapTrackProducerSep2016(const edm::ParameterSet& iConfig) :
+    config_(iConfig),
+    tokenCSC_(consumes<CSCTag::digi_collection>(iConfig.getParameter<edm::InputTag>("CSCInput"))),
+    tokenRPC_(consumes<RPCTag::digi_collection>(iConfig.getParameter<edm::InputTag>("RPCInput"))),
+    verbose_(iConfig.getUntrackedParameter<int>("verbosity")),
+    useCSC_(iConfig.getParameter<bool>("CSCEnable")),
+    useRPC_(iConfig.getParameter<bool>("RPCEnable"))
+{
+  // Make output products
+  produces<EMTFHitExtraCollection>           ("");      // Same as EMTFHit, but with extra emulator-only variables
+  produces<EMTFTrackExtraCollection>         ("");      // Same as EMTFTrack, but with extra emulator-only variables
+  produces<l1t::RegionalMuonCandBxCollection>("EMTF");  // EMTF tracks output to uGMT
+
+  produces<EMTFHitCollection>                ("");      // All CSC LCTs and RPC clusters received by EMTF
+
+  produces<EMTFTrackCollection>              ("");      // All output EMTF tracks, in same format as unpacked data
+}
+
+DummyL1TMuonEndCapTrackProducerSep2016::~DummyL1TMuonEndCapTrackProducerSep2016() {
+
+}
+
+void DummyL1TMuonEndCapTrackProducerSep2016::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  // Create pointers to output products
+  auto out_xhits   = std::make_unique<EMTFHitExtraCollection>();
+  auto out_xtracks = std::make_unique<EMTFTrackExtraCollection>();
+  auto out_cands   = std::make_unique<l1t::RegionalMuonCandBxCollection>();
+
+  auto out_hits    = std::make_unique<EMTFHitCollection>();
+  auto out_tracks  = std::make_unique<EMTFTrackCollection>();
+
+
+  // Get input colections
+  edm::Handle<CSCTag::digi_collection> cscDigis;
+  if (useCSC_)
+    iEvent.getByToken(tokenCSC_, cscDigis);
+
+  edm::Handle<RPCTag::digi_collection> rpcDigis;
+  if (useRPC_)
+    iEvent.getByToken(tokenRPC_, rpcDigis);
+
+  // Do stuff
+  std::vector<int> dummy_vector;
+
+  auto chamber = cscDigis->begin();
+  auto chend   = cscDigis->end();
+  for( ; chamber != chend; ++chamber ) {
+    auto digi = (*chamber).second.first;
+    auto dend = (*chamber).second.second;
+    for( ; digi != dend; ++digi ) {
+      // Do useless things with the digis
+      int dummy = digi->getStrip() * digi->getKeyWG();
+      dummy_vector.push_back(dummy);
+    }
+  }
+
+  for (auto dummy : dummy_vector) {
+    // Do more useless things
+    int dummy2 = dummy * dummy;
+
+    if (verbose_ > 0) {
+      std::cout << "I am a dummy: " << dummy2 << std::endl;
+    }
+  }
+
+
+  // Fill the output products
+  iEvent.put(std::move(out_xhits)  , "");
+  iEvent.put(std::move(out_xtracks), "");
+  iEvent.put(std::move(out_cands)  , "EMTF");
+
+  iEvent.put(std::move(out_hits)   , "");
+  iEvent.put(std::move(out_tracks) , "");
+}
+
+void DummyL1TMuonEndCapTrackProducerSep2016::beginJob() {
+
+}
+
+void DummyL1TMuonEndCapTrackProducerSep2016::endJob() {
+
+}
+
+// Fill 'descriptions' with the allowed parameters
+void DummyL1TMuonEndCapTrackProducerSep2016::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  // The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+// Define this as a plug-in
+DEFINE_FWK_MODULE(DummyL1TMuonEndCapTrackProducerSep2016);

--- a/L1TMuonEndCap/plugins/DummyL1TMuonEndCapTrackProducer.h
+++ b/L1TMuonEndCap/plugins/DummyL1TMuonEndCapTrackProducer.h
@@ -1,0 +1,49 @@
+#ifndef L1TMuonEndCap_DummyL1TMuonEndCapTrackProducerSep2016_h
+#define L1TMuonEndCap_DummyL1TMuonEndCapTrackProducerSep2016_h
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
+#include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
+
+#include "L1TriggerSep2016/L1TMuonEndCap/interface/EMTFCommon.hh"
+
+
+// Class declaration
+class DummyL1TMuonEndCapTrackProducerSep2016 : public edm::EDProducer {
+public:
+  explicit DummyL1TMuonEndCapTrackProducerSep2016(const edm::ParameterSet&);
+  virtual ~DummyL1TMuonEndCapTrackProducerSep2016();
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  virtual void beginJob() override;
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  virtual void endJob() override;
+
+  //virtual void beginRun(edm::Run const&, edm::EventSetup const&);
+  //virtual void endRun(edm::Run const&, edm::EventSetup const&);
+  //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+  //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+
+private:
+  const edm::ParameterSet& config_;
+
+  const edm::EDGetToken tokenCSC_, tokenRPC_;
+
+  int verbose_;
+
+  bool useCSC_, useRPC_;
+};
+
+#endif

--- a/L1TMuonEndCap/python/dummySimEmtfDigisSep2016_cfi.py
+++ b/L1TMuonEndCap/python/dummySimEmtfDigisSep2016_cfi.py
@@ -1,0 +1,16 @@
+import FWCore.ParameterSet.Config as cms
+
+# A dummy module used for debugging/profiling purposes
+
+dummySimEmtfDigisSep2016 = cms.EDProducer("DummyL1TMuonEndCapTrackProducerSep2016",
+    # Verbosity level
+    verbosity = cms.untracked.int32(0),
+
+    # Input collections
+    CSCInput = cms.InputTag('emtfStage2Digis'),
+    RPCInput = cms.InputTag('muonRPCDigis'),
+
+    # Run with CSC, RPC
+    CSCEnable = cms.bool(True),
+    RPCEnable = cms.bool(False),
+)

--- a/L1TMuonEndCap/python/simEmtfDigisSep2016_cfi.py
+++ b/L1TMuonEndCap/python/simEmtfDigisSep2016_cfi.py
@@ -70,9 +70,14 @@ simEmtfDigisSep2016MC = cms.EDProducer("L1TMuonEndCapTrackProducerSep2016",
             "1,22:19:11:8,7:7:7:7,14:7:7:0,14:7:7:0",
             "0,30:23:7:0,7:7:7:7,14:7:7:0,14:7:7:0",
         ),
-        ThetaWindow            = cms.int32(4),
-        ThetaWindowRPC         = cms.int32(8),
         UseSymmetricalPatterns = cms.bool(True),
+    ),
+
+    # Sector processor track-building parameters
+    spTBParams16 = cms.PSet(
+        ThetaWindow    = cms.int32(4),
+        ThetaWindowRPC = cms.int32(8),
+        BugME11Dupes   = cms.bool(False),
     ),
 
     # Sector processor ghost-cancellation parameters
@@ -80,6 +85,7 @@ simEmtfDigisSep2016MC = cms.EDProducer("L1TMuonEndCapTrackProducerSep2016",
         MaxRoadsPerZone   = cms.int32(3),
         MaxTracks         = cms.int32(3),
         UseSecondEarliest = cms.bool(True),
+        BugSameSectorPt0  = cms.bool(False),
     ),
 
     # Sector processor pt-assignment parameters

--- a/L1TMuonEndCap/src/EMTFAngleCalculation.cc
+++ b/L1TMuonEndCap/src/EMTFAngleCalculation.cc
@@ -182,33 +182,39 @@ void EMTFAngleCalculation::calculate_angles(EMTFTrackExtra& track) const {
 
 
   // Apply cuts on dtheta
+
+  // There is a possible bug in FW. After a dtheta pair fails the theta window
+  // cut, the valid flag of the pair is not updated. Later on, theta from
+  // this pair is used to assign the precise theta of the track.
+  std::array<bool, NUM_STATION_PAIRS> best_dtheta_valid_arr_1;
+
   for (int ipair = 0; ipair < NUM_STATION_PAIRS; ++ipair) {
     if (best_has_rpc_arr.at(ipair))
-      best_dtheta_valid_arr.at(ipair) &= (best_dtheta_arr.at(ipair) <= thetaWindowRPC_);
+      best_dtheta_valid_arr_1.at(ipair) = best_dtheta_valid_arr.at(ipair) && (best_dtheta_arr.at(ipair) <= thetaWindowRPC_);
     else
-      best_dtheta_valid_arr.at(ipair) &= (best_dtheta_arr.at(ipair) <= thetaWindow_);
+      best_dtheta_valid_arr_1.at(ipair) = best_dtheta_valid_arr.at(ipair) && (best_dtheta_arr.at(ipair) <= thetaWindow_);
   }
 
   // Find valid segments
   // vmask contains valid station mask = {ME4,ME3,ME2,ME1}. "0b" prefix for binary.
   int vmask1 = 0, vmask2 = 0, vmask3 = 0;
 
-  if (best_dtheta_valid_arr.at(0)) {
+  if (best_dtheta_valid_arr_1.at(0)) {
     vmask1 |= 0b0011;  // 12
   }
-  if (best_dtheta_valid_arr.at(1)) {
+  if (best_dtheta_valid_arr_1.at(1)) {
     vmask1 |= 0b0101;  // 13
   }
-  if (best_dtheta_valid_arr.at(2)) {
+  if (best_dtheta_valid_arr_1.at(2)) {
     vmask1 |= 0b1001;  // 14
   }
-  if (best_dtheta_valid_arr.at(3)) {
+  if (best_dtheta_valid_arr_1.at(3)) {
     vmask2 |= 0b0110;  // 23
   }
-  if (best_dtheta_valid_arr.at(4)) {
+  if (best_dtheta_valid_arr_1.at(4)) {
     vmask2 |= 0b1010;  // 24
   }
-  if (best_dtheta_valid_arr.at(5)) {
+  if (best_dtheta_valid_arr_1.at(5)) {
     vmask3 |= 0b1100;  // 34
   }
 

--- a/L1TMuonEndCap/src/EMTFAngleCalculation.cc
+++ b/L1TMuonEndCap/src/EMTFAngleCalculation.cc
@@ -13,16 +13,18 @@ namespace {
 void EMTFAngleCalculation::configure(
     int verbose, int endcap, int sector, int bx,
     int bxWindow,
-    int thetaWindow, int thetaWindowRPC
+    int thetaWindow, int thetaWindowRPC,
+    bool bugME11Dupes
 ) {
   verbose_ = verbose;
   endcap_  = endcap;
   sector_  = sector;
   bx_      = bx;
 
-  bxWindow_           = bxWindow;
-  thetaWindow_        = thetaWindow;
-  thetaWindowRPC_     = thetaWindowRPC;
+  bxWindow_        = bxWindow;
+  thetaWindow_     = thetaWindow;
+  thetaWindowRPC_  = thetaWindowRPC;
+  bugME11Dupes_    = bugME11Dupes;
 }
 
 void EMTFAngleCalculation::process(
@@ -82,10 +84,15 @@ void EMTFAngleCalculation::calculate_angles(EMTFTrackExtra& track) const {
 
   for (int istation = 0; istation < NUM_STATIONS; ++istation) {
     for (const auto& conv_hit : track.xhits) {
-      if ((conv_hit.station - 1) == istation)
+      if ((conv_hit.station - 1) == istation) {
         st_conv_hits.at(istation).push_back(conv_hit);
+      }
     }
-    assert(st_conv_hits.at(istation).size() <= 2);  // ambiguity in theta is max 2
+
+    if (bugME11Dupes_)
+      assert(st_conv_hits.at(istation).size() <= 4);  // ambiguity in theta is max 4
+    else
+      assert(st_conv_hits.at(istation).size() <= 2);  // ambiguity in theta is max 2
   }
   assert(st_conv_hits.size() == NUM_STATIONS);
 

--- a/L1TMuonEndCap/src/EMTFAngleCalculation.cc
+++ b/L1TMuonEndCap/src/EMTFAngleCalculation.cc
@@ -57,7 +57,7 @@ void EMTFAngleCalculation::process(
   if (verbose_ > 0) {  // debug
     for (const auto& tracks : zone_tracks) {
       for (const auto& track : tracks) {
-        std::cout << "deltas: z: " << track.zone << " pat: " << track.winner << " rank: " << to_hex(track.rank)
+        std::cout << "deltas: z: " << track.zone-1 << " pat: " << track.winner << " rank: " << to_hex(track.rank)
             << " delta_ph: " << array_as_string(track.ptlut_data.delta_ph)
             << " delta_th: " << array_as_string(track.ptlut_data.delta_th)
             << " sign_ph: " << array_as_string(track.ptlut_data.sign_ph)

--- a/L1TMuonEndCap/src/EMTFAngleCalculation.cc
+++ b/L1TMuonEndCap/src/EMTFAngleCalculation.cc
@@ -246,14 +246,24 @@ void EMTFAngleCalculation::calculate_angles(EMTFTrackExtra& track) const {
   int best_pair = -1;
 
   if ((vstat & (1<<1)) != 0) {            // ME2 present
-    if (best_dtheta_valid_arr.at(0))      // 12
+    if (!best_has_rpc_arr.at(0) && best_dtheta_valid_arr.at(0))      // 12
+      best_pair = 0;
+    else if (!best_has_rpc_arr.at(3) && best_dtheta_valid_arr.at(3)) // 23
+      best_pair = 3;
+    else if (!best_has_rpc_arr.at(4) && best_dtheta_valid_arr.at(4)) // 24
+      best_pair = 4;
+    else if (best_dtheta_valid_arr.at(0)) // 12
       best_pair = 0;
     else if (best_dtheta_valid_arr.at(3)) // 23
       best_pair = 3;
     else if (best_dtheta_valid_arr.at(4)) // 24
       best_pair = 4;
   } else if ((vstat & (1<<2)) != 0) {     // ME3 present
-    if (best_dtheta_valid_arr.at(1))      // 13
+    if (!best_has_rpc_arr.at(1) && best_dtheta_valid_arr.at(1))      // 13
+      best_pair = 1;
+    else if (!best_has_rpc_arr.at(5) && best_dtheta_valid_arr.at(5)) // 34
+      best_pair = 5;
+    else if (best_dtheta_valid_arr.at(1)) // 13
       best_pair = 1;
     else if (best_dtheta_valid_arr.at(5)) // 34
       best_pair = 5;

--- a/L1TMuonEndCap/src/EMTFBestTrackSelection.cc
+++ b/L1TMuonEndCap/src/EMTFBestTrackSelection.cc
@@ -6,7 +6,8 @@
 void EMTFBestTrackSelection::configure(
     int verbose, int endcap, int sector, int bx,
     int bxWindow,
-    int maxRoadsPerZone, int maxTracks, bool useSecondEarliest
+    int maxRoadsPerZone, int maxTracks, bool useSecondEarliest,
+    bool bugSameSectorPt0
 ) {
   verbose_ = verbose;
   endcap_  = endcap;
@@ -17,6 +18,7 @@ void EMTFBestTrackSelection::configure(
   maxRoadsPerZone_    = maxRoadsPerZone;
   maxTracks_          = maxTracks;
   useSecondEarliest_  = useSecondEarliest;
+  bugSameSectorPt0_   = bugSameSectorPt0;
 }
 
 void EMTFBestTrackSelection::process(
@@ -215,8 +217,15 @@ void EMTFBestTrackSelection::cancel_one_bx(
       if (larger[i][j] == 0)
         sum += 1;
     }
-    if (sum < maxTracks_)
-      winner[sum][i] = 1; // assign positional winner codes
+
+    if (sum < maxTracks_) {
+      winner[sum][i] = true; // assign positional winner codes
+    }
+
+    if (bugSameSectorPt0_ && sum > 0) {
+      // just keep the best track and kill the rest of them
+      winner[sum][i] = false;
+    }
   }
 
   // Output best tracks according to winner signals
@@ -412,8 +421,15 @@ void EMTFBestTrackSelection::cancel_multi_bx(
       if (larger[i][j] == 0)
         sum += 1;
     }
-    if (sum < maxTracks_)
-      winner[sum][i] = 1; // assign positional winner codes
+
+    if (sum < maxTracks_) {
+      winner[sum][i] = true; // assign positional winner codes
+    }
+
+    if (bugSameSectorPt0_ && sum > 0) {
+      // just keep the best track and kill the rest of them
+      winner[sum][i] = false;
+    }
   }
 
   // Output best tracks according to winner signals

--- a/L1TMuonEndCap/src/EMTFPatternRecognition.cc
+++ b/L1TMuonEndCap/src/EMTFPatternRecognition.cc
@@ -205,14 +205,14 @@ void EMTFPatternRecognition::process(
 
   for (int izone = 0; izone < NUM_ZONES; ++izone) {
     // Skip the zone if no hits and no patterns
-    if (is_zone_empty(izone, extended_conv_hits, patt_lifetime_map))
+    if (is_zone_empty(izone+1, extended_conv_hits, patt_lifetime_map))
       continue;
 
     // Make zone images
-    make_zone_image(izone, extended_conv_hits, zone_images.at(izone));
+    make_zone_image(izone+1, extended_conv_hits, zone_images.at(izone));
 
     // Detect patterns
-    process_single_zone(izone, zone_images.at(izone), patt_lifetime_map, zone_roads.at(izone));
+    process_single_zone(izone+1, zone_images.at(izone), patt_lifetime_map, zone_roads.at(izone));
   }
 
   if (verbose_ > 1) {  // debug
@@ -228,7 +228,7 @@ void EMTFPatternRecognition::process(
   if (verbose_ > 0) {  // debug
     for (const auto& roads : zone_roads) {
       for (const auto& road : reversed(roads)) {
-        std::cout << "pattern: z: " << road.zone << " ph: " << road.key_zhit
+        std::cout << "pattern: z: " << road.zone-1 << " ph: " << road.key_zhit
             << " q: " << to_hex(road.quality_code) << " ly: " << to_binary(road.layer_code, 3)
             << " str: " << to_binary(road.straightness, 3) << " bx: " << road.bx
             << std::endl;
@@ -248,6 +248,7 @@ bool EMTFPatternRecognition::is_zone_empty(
     const std::deque<EMTFHitExtraCollection>& extended_conv_hits,
     const std::map<pattern_ref_t, int>& patt_lifetime_map
 ) const {
+  int izone = zone-1;
   int num_conv_hits = 0;
   int num_patts = 0;
 
@@ -262,7 +263,7 @@ bool EMTFPatternRecognition::is_zone_empty(
       if (conv_hits_it->subsystem == TriggerPrimitive::kRPC)
         continue;  // Don't use RPCs for pattern formation
 
-      if (conv_hits_it->zone_code & (1<<zone)) {  // hit belongs to this zone
+      if (conv_hits_it->zone_code & (1 << izone)) {  // hit belongs to this zone
         num_conv_hits += 1;
       }
     }  // end loop over conv_hits
@@ -285,6 +286,8 @@ void EMTFPatternRecognition::make_zone_image(
     const std::deque<EMTFHitExtraCollection>& extended_conv_hits,
     EMTFPhiMemoryImage& image
 ) const {
+  int izone = zone-1;
+
   std::deque<EMTFHitExtraCollection>::const_iterator ext_conv_hits_it  = extended_conv_hits.begin();
   std::deque<EMTFHitExtraCollection>::const_iterator ext_conv_hits_end = extended_conv_hits.end();
 
@@ -296,7 +299,7 @@ void EMTFPatternRecognition::make_zone_image(
       if (conv_hits_it->subsystem == TriggerPrimitive::kRPC)
         continue;  // Don't use RPCs for pattern formation
 
-      if (conv_hits_it->zone_code & (1 << zone)) {  // hit belongs to this zone
+      if (conv_hits_it->zone_code & (1 << izone)) {  // hit belongs to this zone
         unsigned int layer = conv_hits_it->station - 1;
         unsigned int bit   = conv_hits_it->zone_hit;
         image.set_bit(layer, bit);

--- a/L1TMuonEndCap/src/EMTFPrimitiveConversion.cc
+++ b/L1TMuonEndCap/src/EMTFPrimitiveConversion.cc
@@ -302,7 +302,8 @@ void EMTFPrimitiveConversion::convert_csc_details(EMTFHitExtra& conv_hit) const 
   int clct_pat_corr_sign = (lut().get_ph_patt_corr_sign(conv_hit.pattern) == 0) ? 1 : -1;
 
   // At strip number 0, protect against negative correction
-  if (fw_strip == 0 && clct_pat_corr_sign == -1)
+  bool bugStrip0BeforeFW48200 = false;
+  if (bugStrip0BeforeFW48200 == false && fw_strip == 0 && clct_pat_corr_sign == -1)
     clct_pat_corr = 0;
 
   if (is_10degree) {
@@ -312,7 +313,7 @@ void EMTFPrimitiveConversion::convert_csc_details(EMTFHitExtra& conv_hit) const 
     eighth_strip = fw_strip << 3;  // multiply by 2, uses all 3 bits of pattern correction
     eighth_strip += clct_pat_corr_sign * (clct_pat_corr >> 0);
   }
-  assert(eighth_strip >= 0);
+  assert(bugStrip0BeforeFW48200 == true || eighth_strip >= 0);
 
   // Multiplicative factor for eighth_strip
   int factor = 1024;
@@ -372,7 +373,7 @@ void EMTFPrimitiveConversion::convert_csc_details(EMTFHitExtra& conv_hit) const 
     // Only affect runs before FW changeset 47114 is applied
     // e.g. Run 281707 and earlier
     if (bugME11Dupes_) {
-      bool bugME11DupesBeforeFW47114 = true;
+      bool bugME11DupesBeforeFW47114 = false;
       if (bugME11DupesBeforeFW47114) {
         if (conv_hit.pc_segment == 1) {
           pc_wire_strip_id = (((fw_wire >> 4) & 0x3) << 5) | (0);  // 2-bit from wire, 5-bit from 2-strip

--- a/L1TMuonEndCap/src/EMTFPrimitiveConversion.cc
+++ b/L1TMuonEndCap/src/EMTFPrimitiveConversion.cc
@@ -499,6 +499,7 @@ void EMTFPrimitiveConversion::convert_csc_details(EMTFHitExtra& conv_hit) const 
 
   // ___________________________________________________________________________
   // For later use in angle calculation and best track selection
+  // (in the firmware, this happens in the best_tracks module)
 
   int bt_station = fw_station;
   int bt_history = 0;

--- a/L1TMuonEndCap/src/EMTFPrimitiveMatching.cc
+++ b/L1TMuonEndCap/src/EMTFPrimitiveMatching.cc
@@ -11,7 +11,7 @@ namespace {
 
 void EMTFPrimitiveMatching::configure(
     int verbose, int endcap, int sector, int bx,
-    bool fixZonePhi,
+    bool fixZonePhi, bool useNewZones,
     bool bugME11Dupes
 ) {
   verbose_ = verbose;
@@ -20,6 +20,7 @@ void EMTFPrimitiveMatching::configure(
   bx_      = bx;
 
   fixZonePhi_      = fixZonePhi;
+  useNewZones_     = useNewZones;
   bugME11Dupes_    = bugME11Dupes;
 }
 
@@ -337,6 +338,8 @@ void EMTFPrimitiveMatching::process_single_zone_station(
       // This implementation still differs from FW because I prefer to use a
       // sorting function that is as generic as possible.
       bool use_fw_sorting = true;
+
+      if (useNewZones_)  use_fw_sorting = false;
 
       if (use_fw_sorting && (tmp_phi_differences.front().second->subsystem == TriggerPrimitive::kCSC)) {  // only when the min phi diff is from CSC
         // zone_cham = 4 for [fs_01, fs_02, fs_03, fs_11], or 7 otherwise

--- a/L1TMuonEndCap/src/EMTFPrimitiveMatching.cc
+++ b/L1TMuonEndCap/src/EMTFPrimitiveMatching.cc
@@ -38,7 +38,7 @@ void EMTFPrimitiveMatching::process(
   if (verbose_ > 0) {  // debug
     for (const auto& roads : zone_roads) {
       for (const auto& road : roads) {
-        std::cout << "pattern on match input: z: " << road.zone << " r: " << road.winner
+        std::cout << "pattern on match input: z: " << road.zone-1 << " r: " << road.winner
             << " ph_num: " << road.key_zhit << " ph_q: " << to_hex(road.quality_code)
             << " ly: " << to_binary(road.layer_code, 3) << " str: " << to_binary(road.straightness, 3)
             << std::endl;
@@ -120,7 +120,7 @@ void EMTFPrimitiveMatching::process(
       // zs_phi_differences.at(zs) gets filled with a pair of <phi_diff, conv_hit> for the
       // conv_hit with the lowest phi_diff from the pattern in this station and zone
       process_single_zone_station(
-          istation + 1,
+          izone+1, istation+1,
           zone_roads.at(izone),
           zs_conv_hits.at(zs),
           zs_phi_differences.at(zs)
@@ -138,7 +138,7 @@ void EMTFPrimitiveMatching::process(
         for (int istation = 0; istation < NUM_STATIONS; ++istation) {
           const int zs = (izone*NUM_STATIONS) + istation;
           int ph_diff = zs_phi_differences.at(zs).at(iroad).first;
-          std::cout << "find seg: z: " << road.zone << " r: " << road.winner
+          std::cout << "find seg: z: " << road.zone-1 << " r: " << road.winner
               << " st: " << istation << " ph_diff: " << ph_diff
               << std::endl;
         }
@@ -194,7 +194,7 @@ void EMTFPrimitiveMatching::process(
     for (const auto& tracks : zone_tracks) {
       for (const auto& track : tracks) {
         for (const auto& xhit : track.xhits) {
-          std::cout << "match seg: z: " << track.zone << " pat: " << track.winner <<  " st: " << xhit.station
+          std::cout << "match seg: z: " << track.zone-1 << " pat: " << track.winner <<  " st: " << xhit.station
               << " vi: " << to_binary(0b1, 2) << " hi: " << ((xhit.fs_segment>>4) & 0x3)
               << " ci: " << ((xhit.fs_segment>>1) & 0x7) << " si: " << (xhit.fs_segment & 0x1)
               << " ph: " << xhit.phi_fp << " th: " << xhit.theta_fp
@@ -207,7 +207,7 @@ void EMTFPrimitiveMatching::process(
 }
 
 void EMTFPrimitiveMatching::process_single_zone_station(
-    int station,
+    int zone, int station,
     const EMTFRoadExtraCollection& roads,
     const EMTFHitExtraCollection& conv_hits,
     std::vector<hit_sort_pair_t>& phi_differences

--- a/L1TMuonEndCap/src/EMTFPrimitiveSelection.cc
+++ b/L1TMuonEndCap/src/EMTFPrimitiveSelection.cc
@@ -45,11 +45,31 @@ void EMTFPrimitiveSelection::process(
   TriggerPrimitiveCollection::const_iterator tp_end = muon_primitives.end();
 
   for (; tp_it != tp_end; ++tp_it) {
-    int selected_csc = select_csc(*tp_it); // Returns CSC "link" index (0 - 53)
+    TriggerPrimitive new_tp = *tp_it;  // make a copy and apply patches to this copy
+
+    // Patch the CLCT pattern number
+    // It should be 0-10, see: L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+    bool patchPattern = true;
+    if (patchPattern) {
+      if (new_tp.getCSCData().pattern == 11 || new_tp.getCSCData().pattern == 12) {  // 11, 12 -> 10
+        new_tp.accessCSCData().pattern = 10;
+      }
+    }
+
+    // Patch the LCT quality number
+    // It should be 1-15, see: L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+    bool patchQuality = true;
+    if (patchQuality) {
+      if (new_tp.getCSCData().quality == 0) {  // 0 -> 1
+        new_tp.accessCSCData().quality = 1;
+      }
+    }
+
+    int selected_csc = select_csc(new_tp); // Returns CSC "link" index (0 - 53)
 
     if (selected_csc >= 0) {
       assert(selected_csc < NUM_CSC_CHAMBERS);
-      selected_csc_map[selected_csc].push_back(*tp_it);
+      selected_csc_map[selected_csc].push_back(new_tp);
     }
   }
 
@@ -247,7 +267,8 @@ int EMTFPrimitiveSelection::select_csc(const TriggerPrimitive& muon_primitive) c
     assert(1 <= tp_station && tp_station <= 4);
     assert(1 <= tp_csc_ID && tp_csc_ID <= 9);
     assert(tp_data.strip < 160);
-    assert(tp_data.keywire < 112);
+    //assert(tp_data.keywire < 112);
+    assert(tp_data.keywire < 128);
     assert(tp_data.valid == true);
     assert(tp_data.pattern <= 10);
     assert(tp_data.quality > 0);

--- a/L1TMuonEndCap/src/EMTFSectorProcessor.cc
+++ b/L1TMuonEndCap/src/EMTFSectorProcessor.cc
@@ -17,8 +17,9 @@ void EMTFSectorProcessor::configure(
     int minBX, int maxBX, int bxWindow, int bxShiftCSC, int bxShiftRPC,
     const std::vector<int>& zoneBoundaries, int zoneOverlap, int zoneOverlapRPC,
     bool includeNeighbor, bool duplicateTheta, bool fixZonePhi, bool useNewZones, bool fixME11Edges,
-    const std::vector<std::string>& pattDefinitions, const std::vector<std::string>& symPattDefinitions, int thetaWindow, int thetaWindowRPC, bool useSymPatterns,
-    int maxRoadsPerZone, int maxTracks, bool useSecondEarliest,
+    const std::vector<std::string>& pattDefinitions, const std::vector<std::string>& symPattDefinitions, bool useSymPatterns,
+    int thetaWindow, int thetaWindowRPC, bool bugME11Dupes,
+    int maxRoadsPerZone, int maxTracks, bool useSecondEarliest, bool bugSameSectorPt0,
     bool readPtLUTFile, bool fixMode15HighPt, bool bug9BitDPhi, bool bugMode7CLCT, bool bugNegPt, bool bugGMTPhi
 ) {
   assert(MIN_ENDCAP <= endcap && endcap <= MAX_ENDCAP);
@@ -53,13 +54,16 @@ void EMTFSectorProcessor::configure(
 
   pattDefinitions_    = pattDefinitions;
   symPattDefinitions_ = symPattDefinitions;
+  useSymPatterns_     = useSymPatterns;
+
   thetaWindow_        = thetaWindow;
   thetaWindowRPC_     = thetaWindowRPC;
-  useSymPatterns_     = useSymPatterns;
+  bugME11Dupes_       = bugME11Dupes;
 
   maxRoadsPerZone_    = maxRoadsPerZone;
   maxTracks_          = maxTracks;
   useSecondEarliest_  = useSecondEarliest;
+  bugSameSectorPt0_   = bugSameSectorPt0;
 
   readPtLUTFile_      = readPtLUTFile;
   fixMode15HighPt_    = fixMode15HighPt;
@@ -132,7 +136,8 @@ void EMTFSectorProcessor::process_single_bx(
   prim_sel.configure(
       verbose_, endcap_, sector_, bx,
       bxShiftCSC_, bxShiftRPC_,
-      includeNeighbor_, duplicateTheta_
+      includeNeighbor_, duplicateTheta_,
+      bugME11Dupes_
   );
 
   EMTFPrimitiveConversion prim_conv;
@@ -141,7 +146,8 @@ void EMTFSectorProcessor::process_single_bx(
       verbose_, endcap_, sector_, bx,
       bxShiftCSC_, bxShiftRPC_,
       zoneBoundaries_, zoneOverlap_, zoneOverlapRPC_,
-      duplicateTheta_, fixZonePhi_, useNewZones_, fixME11Edges_
+      duplicateTheta_, fixZonePhi_, useNewZones_, fixME11Edges_,
+      bugME11Dupes_
   );
 
   EMTFPatternRecognition patt_recog;
@@ -155,21 +161,24 @@ void EMTFSectorProcessor::process_single_bx(
   EMTFPrimitiveMatching prim_match;
   prim_match.configure(
       verbose_, endcap_, sector_, bx,
-      fixZonePhi_
+      fixZonePhi_,
+      bugME11Dupes_
   );
 
   EMTFAngleCalculation angle_calc;
   angle_calc.configure(
       verbose_, endcap_, sector_, bx,
       bxWindow_,
-      thetaWindow_, thetaWindowRPC_
+      thetaWindow_, thetaWindowRPC_,
+      bugME11Dupes_
   );
 
   EMTFBestTrackSelection btrack_sel;
   btrack_sel.configure(
       verbose_, endcap_, sector_, bx,
       bxWindow_,
-      maxRoadsPerZone_, maxTracks_, useSecondEarliest_
+      maxRoadsPerZone_, maxTracks_, useSecondEarliest_,
+      bugSameSectorPt0_
   );
 
   EMTFPtAssignment pt_assign;

--- a/L1TMuonEndCap/src/EMTFSectorProcessor.cc
+++ b/L1TMuonEndCap/src/EMTFSectorProcessor.cc
@@ -161,7 +161,7 @@ void EMTFSectorProcessor::process_single_bx(
   EMTFPrimitiveMatching prim_match;
   prim_match.configure(
       verbose_, endcap_, sector_, bx,
-      fixZonePhi_,
+      fixZonePhi_, useNewZones_,
       bugME11Dupes_
   );
 

--- a/L1TMuonEndCap/src/EMTFSubsystemCollector.cc
+++ b/L1TMuonEndCap/src/EMTFSubsystemCollector.cc
@@ -13,8 +13,7 @@ void EMTFSubsystemCollector::extractPrimitives(
     TriggerPrimitiveCollection& out
 ) {
   edm::Handle<CSCTag::digi_collection> cscDigis;
-  if (!token.isUninitialized())
-      iEvent.getByToken(token, cscDigis);
+  iEvent.getByToken(token, cscDigis);
 
   auto chamber = cscDigis->begin();
   auto chend   = cscDigis->end();
@@ -38,8 +37,7 @@ void EMTFSubsystemCollector::extractPrimitives(
     TriggerPrimitiveCollection& out
 ) {
   edm::Handle<RPCTag::digi_collection> rpcDigis;
-  if (!token.isUninitialized())
-      iEvent.getByToken(token, rpcDigis);
+  iEvent.getByToken(token, rpcDigis);
 
   auto chamber = rpcDigis->begin();
   auto chend   = rpcDigis->end();

--- a/L1TMuonEndCap/src/EMTFTrackFinder.cc
+++ b/L1TMuonEndCap/src/EMTFTrackFinder.cc
@@ -40,14 +40,18 @@ EMTFTrackFinder::EMTFTrackFinder(const edm::ParameterSet& iConfig, edm::Consumes
   const auto& spPRParams16 = config_.getParameter<edm::ParameterSet>("spPRParams16");
   auto pattDefinitions    = spPRParams16.getParameter<std::vector<std::string> >("PatternDefinitions");
   auto symPattDefinitions = spPRParams16.getParameter<std::vector<std::string> >("SymPatternDefinitions");
-  auto thetaWindow        = spPRParams16.getParameter<int>("ThetaWindow");
-  auto thetaWindowRPC     = spPRParams16.getParameter<int>("ThetaWindowRPC");
   auto useSymPatterns     = spPRParams16.getParameter<bool>("UseSymmetricalPatterns");
+
+  const auto& spTBParams16 = config_.getParameter<edm::ParameterSet>("spTBParams16");
+  auto thetaWindow        = spTBParams16.getParameter<int>("ThetaWindow");
+  auto thetaWindowRPC     = spTBParams16.getParameter<int>("ThetaWindowRPC");
+  auto bugME11Dupes       = spTBParams16.getParameter<bool>("BugME11Dupes");
 
   const auto& spGCParams16 = config_.getParameter<edm::ParameterSet>("spGCParams16");
   auto maxRoadsPerZone    = spGCParams16.getParameter<int>("MaxRoadsPerZone");
   auto maxTracks          = spGCParams16.getParameter<int>("MaxTracks");
   auto useSecondEarliest  = spGCParams16.getParameter<bool>("UseSecondEarliest");
+  auto bugSameSectorPt0   = spGCParams16.getParameter<bool>("BugSameSectorPt0");
 
   const auto& spPAParams16 = config_.getParameter<edm::ParameterSet>("spPAParams16");
   auto bdtXMLDir          = spPAParams16.getParameter<std::string>("BDTXMLDir");
@@ -79,8 +83,9 @@ EMTFTrackFinder::EMTFTrackFinder(const edm::ParameterSet& iConfig, edm::Consumes
             minBX, maxBX, bxWindow, bxShiftCSC, bxShiftRPC,
             zoneBoundaries, zoneOverlap, zoneOverlapRPC,
             includeNeighbor, duplicateTheta, fixZonePhi, useNewZones, fixME11Edges,
-            pattDefinitions, symPattDefinitions, thetaWindow, thetaWindowRPC, useSymPatterns,
-            maxRoadsPerZone, maxTracks, useSecondEarliest,
+            pattDefinitions, symPattDefinitions, useSymPatterns,
+            thetaWindow, thetaWindowRPC, bugME11Dupes,
+            maxRoadsPerZone, maxTracks, useSecondEarliest, bugSameSectorPt0,
             readPtLUTFile, fixMode15HighPt, bug9BitDPhi, bugMode7CLCT, bugNegPt, bugGMTPhi
         );
       }

--- a/L1TMuonEndCap/src/GeometryTranslator.cc
+++ b/L1TMuonEndCap/src/GeometryTranslator.cc
@@ -13,12 +13,15 @@
 #include "L1Trigger/DTUtilities/interface/DTTrigGeom.h"
 #include "Geometry/RPCGeometry/interface/RPCGeometry.h"
 
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+
 #include <cmath> // for pi
 
 using namespace L1TMuonEndCap;
 
 GeometryTranslator::GeometryTranslator():
-  _geom_cache_id(0ULL) {
+  _geom_cache_id(0ULL), _magfield_cache_id(0ULL) {
 }
 
 GeometryTranslator::~GeometryTranslator() {
@@ -105,6 +108,13 @@ void GeometryTranslator::checkAndUpdateGeometry(const edm::EventSetup& es) {
     geom.get(_geocsc);
     geom.get(_geodt);
     _geom_cache_id = geomid;
+  }
+
+  const IdealMagneticFieldRecord& magfield = es.get<IdealMagneticFieldRecord>();
+  unsigned long long magfieldid = magfield.cacheIdentifier();
+  if( _magfield_cache_id != magfieldid ) {
+    magfield.get(_magfield);
+    _magfield_cache_id = magfieldid;
   }
 }
 

--- a/L1TMuonEndCap/src/helper.hh
+++ b/L1TMuonEndCap/src/helper.hh
@@ -227,4 +227,19 @@ namespace {
     }
   }
 
+  // See above. 'Hint' is provided to force the very first division. This is needed to match FW.
+  template<typename RandomAccessIterator, typename Compare, typename Compare3>
+  void merge_sort3_with_hint(RandomAccessIterator first, RandomAccessIterator last, Compare cmp, Compare3 cmp3, std::ptrdiff_t d)
+  {
+    const std::ptrdiff_t len = std::distance(first, last);
+    if (len > 1) {
+      RandomAccessIterator one_third = std::next(first, d);
+      RandomAccessIterator two_third = std::next(first, d * 2);
+      merge_sort3(first, one_third, cmp, cmp3);
+      merge_sort3(one_third, two_third, cmp, cmp3);
+      merge_sort3(two_third, last, cmp, cmp3);
+      merge_sort_merge3(first, one_third, two_third, last, cmp, cmp3);
+    }
+  }
+
 }  // namespace

--- a/L1TMuonEndCap/src/helper.hh
+++ b/L1TMuonEndCap/src/helper.hh
@@ -4,6 +4,7 @@
 
 namespace {
 
+  // Return an integer as a hex string
   template<typename INT>
   std::string to_hex(INT i) {
     std::stringstream s;
@@ -11,6 +12,7 @@ namespace {
     return s.str();
   }
 
+  // Return an integer as a binary string
   template<typename INT>
   std::string to_binary(INT i, int n) {
     std::stringstream s;
@@ -24,9 +26,11 @@ namespace {
     return s.str();
   }
 
+  // Return the size of a 1D plain array
   template<typename T, size_t N>
   constexpr size_t array_size(T(&)[N]) { return N; }
 
+  // Return the elements of a 1D plain array as a string (elements are separated by ' ')
   template<typename T, size_t N>
   std::string array_as_string(const T(&arr)[N]) {
     std::stringstream s;
@@ -38,6 +42,11 @@ namespace {
     return s.str();
   }
 
+  // This function allows one to loop over a container in reversed order using C++11 for(auto ...) loop
+  // e.g.
+  //   for (auto x: reversed(v)) {
+  //     // do something
+  //   }
   // See http://stackoverflow.com/a/21510185
   namespace details {
     template <class T> struct _reversed {
@@ -48,6 +57,7 @@ namespace {
   }
   template <class T> details::_reversed<T> reversed(T& t) { return details::_reversed<T>(t); }
 
+  // Split a string by delimiters (default: ' ') into a vector of string
   // See http://stackoverflow.com/a/53878
   template <class STR=std::string>
   std::vector<STR> split_string(const std::string& s, char c = ' ', char d = ' ') {
@@ -62,6 +72,8 @@ namespace {
     return result;
   }
 
+  // Flatten a vector<vector<T> > into a vector<T>
+  // The input type T can be different from the output type T
   template <class T1, class T2>
   void flatten_container(const T1& input, T2& output) {
     typename T1::const_iterator it;
@@ -70,6 +82,10 @@ namespace {
     }
   }
 
+  // A simple nearest-neighbor clustering algorithm
+  // It iterates through a sorted container once, whenever the 'adjacent'
+  // comparison between two elements evaluates to true, the 'cluster'
+  // operator is called to merge them.
   template <class ForwardIt, class BinaryPredicate, class BinaryOp>
   ForwardIt adjacent_cluster(ForwardIt first, ForwardIt last, BinaryPredicate adjacent, BinaryOp cluster) {
     if (first == last) return last;
@@ -83,6 +99,132 @@ namespace {
       }
     }
     return ++result;
+  }
+
+  // Textbook merge sort algorithm with the same interface as std::sort()
+  // An internal buffer of the same size as the container is used internally.
+  template<typename RandomAccessIterator, typename Compare = std::less<> >
+  void merge_sort_merge(RandomAccessIterator first, RandomAccessIterator middle, RandomAccessIterator last, Compare cmp)
+  {
+    const std::ptrdiff_t len = std::distance(first, last);
+    typedef typename std::iterator_traits<RandomAccessIterator>::value_type value_type;
+    typedef typename std::iterator_traits<RandomAccessIterator>::pointer pointer;
+    std::pair<pointer, std::ptrdiff_t> p = std::get_temporary_buffer<value_type>(len);
+    pointer buf = p.first;
+    pointer buf_end = std::next(p.first, p.second);
+
+    RandomAccessIterator first1 = first;
+    RandomAccessIterator last1  = middle;
+    RandomAccessIterator first2 = middle;
+    RandomAccessIterator last2  = last;
+
+    while (first1 != last1 && first2 != last2) {
+      if (cmp(*first2, *first1)) {
+        *buf++ = *first2++;
+      } else {
+        *buf++ = *first1++;
+      }
+    }
+    while (first1 != last1) {
+      *buf++ = *first1++;
+    }
+    while (first2 != last2) {
+      *buf++ = *first2++;
+    }
+
+    buf = p.first;
+    std::copy(buf, buf_end, first);
+    std::return_temporary_buffer(p.first);
+  }
+
+  // See above
+  template<typename RandomAccessIterator, typename Compare = std::less<> >
+  void merge_sort(RandomAccessIterator first, RandomAccessIterator last, Compare cmp)
+  {
+    const std::ptrdiff_t len = std::distance(first, last);
+    if (len > 1) {
+      RandomAccessIterator middle = std::next(first, len / 2);
+      merge_sort(first, middle, cmp);
+      merge_sort(middle, last, cmp);
+      merge_sort_merge(first, middle, last, cmp);
+    }
+  }
+
+  // An extended version of the merge sort algorithm to incorporate a 3-way
+  // comparator. It resorts back to 2-way comparator when one of the three
+  // lists to be merged is empty.
+  template<typename RandomAccessIterator, typename Compare, typename Compare3>
+  void merge_sort_merge3(RandomAccessIterator first, RandomAccessIterator one_third, RandomAccessIterator two_third, RandomAccessIterator last, Compare cmp, Compare3 cmp3)
+  {
+    const std::ptrdiff_t len = std::distance(first, last);
+    typedef typename std::iterator_traits<RandomAccessIterator>::value_type value_type;
+    typedef typename std::iterator_traits<RandomAccessIterator>::pointer pointer;
+    std::pair<pointer, std::ptrdiff_t> p = std::get_temporary_buffer<value_type>(len);
+    pointer buf = p.first;
+    pointer buf_end = std::next(p.first, p.second);
+
+    RandomAccessIterator first1 = first;
+    RandomAccessIterator last1  = one_third;
+    RandomAccessIterator first2 = one_third;
+    RandomAccessIterator last2  = two_third;
+    RandomAccessIterator first3 = two_third;
+    RandomAccessIterator last3  = last;
+
+    while (first1 != last1 && first2 != last2 && first3 != last3) {
+      int rr = cmp3(*first1, *first2, *first3);
+      if (rr == 0) {
+        *buf++ = *first1++;
+      } else if (rr == 1) {
+        *buf++ = *first2++;
+      } else if (rr == 2) {
+        *buf++ = *first3++;
+      }
+    }
+
+    if (first3 == last3) {
+      // do nothing
+    } else if (first2 == last2) {
+      first2 = first3;
+      last2  = last3;
+    } else if (first1 == last1) {
+      first1 = first2;
+      last1  = last2;
+      first2 = first3;
+      last2  = last3;
+    }
+
+    while (first1 != last1 && first2 != last2) {
+      if (cmp(*first2, *first1)) {
+        *buf++ = *first2++;
+      } else {
+        *buf++ = *first1++;
+      }
+    }
+    while (first1 != last1) {
+      *buf++ = *first1++;
+    }
+    while (first2 != last2) {
+      *buf++ = *first2++;
+    }
+
+    buf = p.first;
+    std::copy(buf, buf_end, first);
+    std::return_temporary_buffer(p.first);
+  }
+
+  // See above
+  template<typename RandomAccessIterator, typename Compare, typename Compare3>
+  void merge_sort3(RandomAccessIterator first, RandomAccessIterator last, Compare cmp, Compare3 cmp3)
+  {
+    const std::ptrdiff_t len = std::distance(first, last);
+    if (len > 1) {
+      RandomAccessIterator one_third = std::next(first, (len+2) / 3);
+      RandomAccessIterator two_third = std::next(first, (len+2) / 3 * 2);
+      merge_sort3(first, one_third, cmp, cmp3);
+      merge_sort3(one_third, two_third, cmp, cmp3);
+      merge_sort3(two_third, last, cmp, cmp3);
+      merge_sort_merge3(first, one_third, two_third, last, cmp, cmp3);
+    }
   }
 
 }  // namespace

--- a/L1TMuonEndCap/test/tools/MakeEMTFAngleLUT.cc
+++ b/L1TMuonEndCap/test/tools/MakeEMTFAngleLUT.cc
@@ -1,3 +1,8 @@
+//!
+//! This piece of code is obsolete and completely unused. It is kept as an 
+//! example to show how to access certain geometry information.
+//! 
+
 #include <cassert>
 #include <cmath>
 #include <memory>

--- a/L1TMuonEndCap/test/tools/MakeEMTFAngleLUT.cc
+++ b/L1TMuonEndCap/test/tools/MakeEMTFAngleLUT.cc
@@ -132,8 +132,8 @@ void MakeEMTFAngleLUT::generateLUTs() {
   };
   if (isFront) {}  // get around GCC unused-but-set-variable error
 
-  // Save z positions for ME1/1, ME1/2, ME1/3, ME2/2, ME3/2, ME4/2, RE1/2, RE2/2, RE3/2, RE4/2
-  std::vector<double> z_positions(20, 0.);
+  // Save z positions for ME1/1, ME1/2, ME1/3, ME2/2, ME3/2, ME4/2, RE1/2, RE1/3, RE2/2, RE3/2, RE4/2
+  std::vector<double> z_positions(22, 0.);
 
   // CSC
   for (CSCGeometry::DetUnitContainer::const_iterator it = geocsc.detUnits().begin(); it != geocsc.detUnits().end(); ++it) {
@@ -195,8 +195,10 @@ void MakeEMTFAngleLUT::generateLUTs() {
     //const RPCChamber* chamber = roll->chamber();  // like GeomDet
     //assert(chamber != nullptr);
     const RPCDetId& rpcDetId = roll->id();
-    if (rpcDetId.region() == 0 || (rpcDetId.station() <= 2 && rpcDetId.ring() == 3))  // skip barrel, RE1/3, RE2/3
+    if (rpcDetId.region() == 0)  // skip barrel
       continue;
+    //if (rpcDetId.region() == 0 || (rpcDetId.station() <= 2 && rpcDetId.ring() == 3))  // skip barrel, RE1/3, RE2/3
+    //  continue;
     double zpos = roll->surface().position().z();  // [cm]
     //std::cout << "RPC: " << rpcDetId.region() << " " << rpcDetId.ring() << " " << rpcDetId.station() << " " << rpcDetId.sector() << " " << rpcDetId.layer() << " " << rpcDetId.subsector() << " " << rpcDetId.roll() << " " << zpos << std::endl;
 
@@ -208,23 +210,29 @@ void MakeEMTFAngleLUT::generateLUTs() {
         } else if (rpcDetId.subsector() == 1) {  // rear
           z_positions[13] = zpos;
         }
-      } else if (rpcDetId.station() == 2 && rpcDetId.ring() == 2) {
+      } else if (rpcDetId.station() == 1 && rpcDetId.ring() == 3) {
         if        (rpcDetId.subsector() == 2) {  // front
           z_positions[14] = zpos;
         } else if (rpcDetId.subsector() == 1) {  // rear
           z_positions[15] = zpos;
         }
-      } else if (rpcDetId.station() == 3 && rpcDetId.ring() == 2) {
+      } else if (rpcDetId.station() == 2 && rpcDetId.ring() == 2) {
         if        (rpcDetId.subsector() == 2) {  // front
           z_positions[16] = zpos;
         } else if (rpcDetId.subsector() == 1) {  // rear
           z_positions[17] = zpos;
         }
-      } else if (rpcDetId.station() == 4 && rpcDetId.ring() == 2) {
+      } else if (rpcDetId.station() == 3 && rpcDetId.ring() == 2) {
         if        (rpcDetId.subsector() == 2) {  // front
           z_positions[18] = zpos;
         } else if (rpcDetId.subsector() == 1) {  // rear
           z_positions[19] = zpos;
+        }
+      } else if (rpcDetId.station() == 4 && rpcDetId.ring() == 2) {
+        if        (rpcDetId.subsector() == 2) {  // front
+          z_positions[20] = zpos;
+        } else if (rpcDetId.subsector() == 1) {  // rear
+          z_positions[21] = zpos;
         }
       }
     }
@@ -275,13 +283,13 @@ void MakeEMTFAngleLUT::generateLUTs() {
       common_zpos = average(z_positions[8], z_positions[9]);
     } else if (iz == 10 || iz == 11) {  // ME4/2
       common_zpos = average(z_positions[10], z_positions[11]);
-    } else if (iz == 12 || iz == 13) {  // RE1/2
+    } else if (iz == 12 || iz == 13 || iz == 14 || iz == 15) {  // RE1/2, RE1/3
       common_zpos = average(z_positions[2], z_positions[3]);
-    } else if (iz == 14 || iz == 15) {  // RE2/2
+    } else if (iz == 16 || iz == 17) {  // RE2/2
       common_zpos = average(z_positions[6], z_positions[7]);
-    } else if (iz == 16 || iz == 17) {  // RE3/2
+    } else if (iz == 18 || iz == 19) {  // RE3/2
       common_zpos = average(z_positions[8], z_positions[9]);
-    } else if (iz == 18 || iz == 19) {  // RE4/2
+    } else if (iz == 20 || iz == 21) {  // RE4/2
       common_zpos = average(z_positions[10], z_positions[11]);
     }
 

--- a/L1TMuonEndCap/test/tools/MakeEMTFAngleLUT.cc
+++ b/L1TMuonEndCap/test/tools/MakeEMTFAngleLUT.cc
@@ -1,0 +1,323 @@
+#include <cassert>
+#include <cmath>
+#include <memory>
+#include <vector>
+#include <fstream>
+#include <iostream>
+
+#include "TFile.h"
+#include "TTree.h"
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "Geometry/CSCGeometry/interface/CSCGeometry.h"
+#include "Geometry/RPCGeometry/interface/RPCGeometry.h"
+#include "Geometry/DTGeometry/interface/DTGeometry.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+
+//#include "DataFormats/MuonDetId/interface/CSCTriggerNumbering.h"
+#include "L1Trigger/CSCCommonTrigger/interface/CSCConstants.h"
+
+#include "L1TriggerSep2016/L1TMuonEndCap/interface/GeometryTranslator.h"
+#include "L1TriggerSep2016/L1TMuonEndCap/interface/MuonTriggerPrimitive.h"
+#include "L1TriggerSep2016/L1TMuonEndCap/interface/MuonTriggerPrimitiveFwd.h"
+
+typedef L1TMuonEndCap::GeometryTranslator         GeometryTranslator;
+typedef L1TMuonEndCap::TriggerPrimitive           TriggerPrimitive;
+typedef L1TMuonEndCap::TriggerPrimitiveCollection TriggerPrimitiveCollection;
+
+#include "helper.hh"
+
+
+class MakeEMTFAngleLUT : public edm::EDAnalyzer {
+public:
+  explicit MakeEMTFAngleLUT(const edm::ParameterSet&);
+  virtual ~MakeEMTFAngleLUT();
+
+private:
+  //virtual void beginJob();
+  //virtual void endJob();
+
+  virtual void beginRun(const edm::Run&, const edm::EventSetup&);
+  virtual void endRun(const edm::Run&, const edm::EventSetup&);
+
+  virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup);
+
+  void generateLUTs();
+
+private:
+  GeometryTranslator geometry_translator_;
+
+  const edm::ParameterSet config_;
+
+  int verbose_;
+
+  std::string outfile_;
+
+  bool done_;
+
+  /// Event setup
+
+};
+
+
+// _____________________________________________________________________________
+MakeEMTFAngleLUT::MakeEMTFAngleLUT(const edm::ParameterSet& iConfig) :
+    geometry_translator_(),
+    config_(iConfig),
+    verbose_(iConfig.getUntrackedParameter<int>("verbosity")),
+    outfile_(iConfig.getParameter<std::string>("outfile")),
+    done_(false)
+{
+  assert(CSCConstants::KEY_CLCT_LAYER == CSCConstants::KEY_ALCT_LAYER);
+}
+
+MakeEMTFAngleLUT::~MakeEMTFAngleLUT() {}
+
+void MakeEMTFAngleLUT::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
+  geometry_translator_.checkAndUpdateGeometry(iSetup);
+}
+
+void MakeEMTFAngleLUT::endRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
+
+}
+
+void MakeEMTFAngleLUT::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  if (done_)  return;
+
+  generateLUTs();
+
+  done_ = true;
+  return;
+}
+
+// _____________________________________________________________________________
+void MakeEMTFAngleLUT::generateLUTs() {
+
+  const CSCGeometry& geocsc = geometry_translator_.getCSCGeometry();
+  const RPCGeometry& georpc = geometry_translator_.getRPCGeometry();
+  const MagneticField& magfield = geometry_translator_.getMagneticField();
+
+  auto average = [](double x, double y) {
+    return 0.5 * (x + y);
+  };
+
+  // from RecoMuon/DetLayers/src/MuonCSCDetLayerGeometryBuilder.cc
+  // from RecoMuon/DetLayers/src/MuonRPCDetLayerGeometryBuilder.cc
+  auto isFront = [](int subsystem, int station, int ring, int chamber, int subsector) {
+    bool result = false;
+
+    if (subsystem == TriggerPrimitive::kCSC) {
+      bool isOverlapping = !(station == 1 && ring == 3);
+      // not overlapping means back
+      if(isOverlapping)
+      {
+        bool isEven = (chamber % 2 == 0);
+        // odd chambers are bolted to the iron, which faces
+        // forward in 1&2, backward in 3&4, so...
+        result = (station < 3) ? isEven : !isEven;
+      }
+    } else if (subsystem == TriggerPrimitive::kRPC) {
+      // 10 degree rings have odd subsectors in front
+      result = (subsector % 2 == 0);
+    }
+    return result;
+  };
+  if (isFront) {}  // get around GCC unused-but-set-variable error
+
+  // Save z positions for ME1/1, ME1/2, ME1/3, ME2/2, ME3/2, ME4/2, RE1/2, RE2/2, RE3/2, RE4/2
+  std::vector<double> z_positions(20, 0.);
+
+  // CSC
+  for (CSCGeometry::DetUnitContainer::const_iterator it = geocsc.detUnits().begin(); it != geocsc.detUnits().end(); ++it) {
+    const CSCLayer* layer = dynamic_cast<const CSCLayer*>(*it);  // like GeomDetUnit
+    assert(layer != nullptr);
+    const CSCChamber* chamber = layer->chamber();  // like GeomDet
+    assert(chamber != nullptr);
+    const CSCDetId& cscDetId = chamber->id();
+    //double zpos = chamber->surface().position().z();  // [cm]
+    double zpos = chamber->layer(CSCConstants::KEY_ALCT_LAYER)->surface().position().z();  // [cm]
+    //std::cout << "CSC: " << cscDetId.endcap() << " " << cscDetId.station() << " " << cscDetId.ring() << " " << cscDetId.chamber() << " " << cscDetId.layer() << " " << zpos << std::endl;
+
+    // Save the numbers
+    if (cscDetId.endcap() == 1 && (cscDetId.chamber() == 1 || cscDetId.chamber() == 2)) {
+      if (cscDetId.station() == 1 && cscDetId.ring() == 1) {
+        if        (cscDetId.chamber() == 2) {  // front
+          z_positions[0] = zpos;
+        } else if (cscDetId.chamber() == 1) {  // rear
+          z_positions[1] = zpos;
+        }
+      } else if (cscDetId.station() == 1 && cscDetId.ring() == 2) {
+        if        (cscDetId.chamber() == 2) {  // front
+          z_positions[2] = zpos;
+        } else if (cscDetId.chamber() == 1) {  // rear
+          z_positions[3] = zpos;
+        }
+      } else if (cscDetId.station() == 1 && cscDetId.ring() == 3) {
+        if        (cscDetId.chamber() == 2) {  // front
+          z_positions[4] = zpos;
+        } else if (cscDetId.chamber() == 1) {  // rear
+          z_positions[5] = zpos;
+        }
+      } else if (cscDetId.station() == 2 && cscDetId.ring() == 2) {
+        if        (cscDetId.chamber() == 2) {  // front
+          z_positions[6] = zpos;
+        } else if (cscDetId.chamber() == 1) {  // rear
+          z_positions[7] = zpos;
+        }
+      } else if (cscDetId.station() == 3 && cscDetId.ring() == 2) {
+        if        (cscDetId.chamber() == 1) {  // front
+          z_positions[8] = zpos;
+        } else if (cscDetId.chamber() == 2) {  // rear
+          z_positions[9] = zpos;
+        }
+      } else if (cscDetId.station() == 4 && cscDetId.ring() == 2) {
+        if        (cscDetId.chamber() == 1) {  // front
+          z_positions[10] = zpos;
+        } else if (cscDetId.chamber() == 2) {  // rear
+          z_positions[11] = zpos;
+        }
+      }
+    }
+  }  // end loop over CSC detUnits
+
+  // RPC
+  for (RPCGeometry::DetUnitContainer::const_iterator it = georpc.detUnits().begin(); it != georpc.detUnits().end(); ++it) {
+    const RPCRoll* roll = dynamic_cast<const RPCRoll*>(*it);  // like GeomDetUnit
+    assert(roll != nullptr);
+    //const RPCChamber* chamber = roll->chamber();  // like GeomDet
+    //assert(chamber != nullptr);
+    const RPCDetId& rpcDetId = roll->id();
+    if (rpcDetId.region() == 0 || (rpcDetId.station() <= 2 && rpcDetId.ring() == 3))  // skip barrel, RE1/3, RE2/3
+      continue;
+    double zpos = roll->surface().position().z();  // [cm]
+    //std::cout << "RPC: " << rpcDetId.region() << " " << rpcDetId.ring() << " " << rpcDetId.station() << " " << rpcDetId.sector() << " " << rpcDetId.layer() << " " << rpcDetId.subsector() << " " << rpcDetId.roll() << " " << zpos << std::endl;
+
+    // Save the numbers
+    if (rpcDetId.region() == 1 && rpcDetId.sector() == 1 && rpcDetId.roll() == 1 && (rpcDetId.subsector() == 1 || rpcDetId.subsector() == 2)) {
+      if (rpcDetId.station() == 1 && rpcDetId.ring() == 2) {
+        if        (rpcDetId.subsector() == 2) {  // front
+          z_positions[12] = zpos;
+        } else if (rpcDetId.subsector() == 1) {  // rear
+          z_positions[13] = zpos;
+        }
+      } else if (rpcDetId.station() == 2 && rpcDetId.ring() == 2) {
+        if        (rpcDetId.subsector() == 2) {  // front
+          z_positions[14] = zpos;
+        } else if (rpcDetId.subsector() == 1) {  // rear
+          z_positions[15] = zpos;
+        }
+      } else if (rpcDetId.station() == 3 && rpcDetId.ring() == 2) {
+        if        (rpcDetId.subsector() == 2) {  // front
+          z_positions[16] = zpos;
+        } else if (rpcDetId.subsector() == 1) {  // rear
+          z_positions[17] = zpos;
+        }
+      } else if (rpcDetId.station() == 4 && rpcDetId.ring() == 2) {
+        if        (rpcDetId.subsector() == 2) {  // front
+          z_positions[18] = zpos;
+        } else if (rpcDetId.subsector() == 1) {  // rear
+          z_positions[19] = zpos;
+        }
+      }
+    }
+  }  // end loop over RPC detUnits
+
+  // Verbose
+  if (verbose_) {
+    std::cout << "z positions:" << std::endl;
+    for (const auto& zpos : z_positions) {
+      std::cout << zpos << std::endl;
+    }
+    std::cout << std::endl;
+
+    std::cout << "common planes:" << std::endl;
+    std::cout << average(z_positions[0], z_positions[1]) << std::endl;
+    std::cout << average(z_positions[2], z_positions[3]) << std::endl;
+    std::cout << average(z_positions[6], z_positions[7]) << std::endl;
+    std::cout << average(z_positions[8], z_positions[9]) << std::endl;
+    std::cout << average(z_positions[10], z_positions[11]) << std::endl;
+    std::cout << std::endl;
+  }
+
+
+  // Calculate the coefficients
+  auto get_eta_bin_center = [](int b) {
+    // nbinsx, xlow, xup = 2048, 1.1, 2.5
+    double c = 1.1 + (2.5 - 1.1)/2048. * (0.5 + static_cast<double>(b));
+    return c;
+  };
+
+  int num_z_bins = z_positions.size();
+  int num_eta_bins = 2048;
+
+  std::vector<double> coefficients;
+
+  // Loop over z bins
+  for (int iz = 0; iz < num_z_bins; ++iz) {
+
+    // Find common plane
+    double common_zpos = 0.;
+    if (iz == 0 || iz == 1) {  // ME1/1
+      common_zpos = average(z_positions[0], z_positions[1]);
+    } else if (iz == 2 || iz == 3 || iz == 4 || iz == 5) {  // ME1/2, ME1/3
+      common_zpos = average(z_positions[2], z_positions[3]);
+    } else if (iz == 6 || iz == 7) {  // ME2/2
+      common_zpos = average(z_positions[6], z_positions[7]);
+    } else if (iz == 8 || iz == 9) {  // ME3/2
+      common_zpos = average(z_positions[8], z_positions[9]);
+    } else if (iz == 10 || iz == 11) {  // ME4/2
+      common_zpos = average(z_positions[10], z_positions[11]);
+    } else if (iz == 12 || iz == 13) {  // RE1/2
+      common_zpos = average(z_positions[2], z_positions[3]);
+    } else if (iz == 14 || iz == 15) {  // RE2/2
+      common_zpos = average(z_positions[6], z_positions[7]);
+    } else if (iz == 16 || iz == 17) {  // RE3/2
+      common_zpos = average(z_positions[8], z_positions[9]);
+    } else if (iz == 18 || iz == 19) {  // RE4/2
+      common_zpos = average(z_positions[10], z_positions[11]);
+    }
+
+    // Loop over eta bins
+    for (int ieta = 0; ieta < num_eta_bins; ++ieta) {
+
+      // Find magnetic field strength
+      double zpos     = z_positions.at(iz);
+      double deltaZ   = zpos - common_zpos;
+      double eta      = get_eta_bin_center(ieta);
+      double cotTheta = std::sinh(eta);
+      double r        = zpos / cotTheta;
+
+      const GlobalPoint gp(r, 0, zpos);  // phi = 0
+      double bz       = magfield.inTesla(gp).z();  // [Tesla]
+
+      // Calculate the coefficient
+      // coeff = deltaZ * (-0.5) * 0.003 * bz
+      double coeff = deltaZ * (-0.5) * 0.003 * bz;
+      coefficients.push_back(coeff);
+    }
+  }
+  assert(coefficients.size() == (unsigned) (num_z_bins * num_eta_bins));
+
+  // Write
+  {
+    TFile* tfile = TFile::Open(outfile_.c_str(), "RECREATE");
+    TTree* ttree = new TTree("tree", "tree");
+    ttree->Branch("coefficients", &coefficients);
+    ttree->Fill();
+    tfile->Write();
+    std::cout << "Wrote file: " << outfile_ << std::endl;
+  }
+
+}
+
+// DEFINE THIS AS A PLUG-IN
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(MakeEMTFAngleLUT);

--- a/L1TMuonEndCap/test/tools/make_anglelut.py
+++ b/L1TMuonEndCap/test/tools/make_anglelut.py
@@ -1,3 +1,7 @@
+#
+# This cfg calls MakeEMTFAngleLUT which is obsolete and completely unused.
+#
+
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Whatever")

--- a/L1TMuonEndCap/test/tools/make_anglelut.py
+++ b/L1TMuonEndCap/test/tools/make_anglelut.py
@@ -1,0 +1,31 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("Whatever")
+
+#process.load('Configuration.Geometry.GeometryExtended2016Reco_cff')
+process.load("Configuration.StandardSequences.GeometryDB_cff")  # load from DB
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
+print "Using GlobalTag: %s" % process.GlobalTag.globaltag.value()
+
+# Fake alignment is/should be ideal geometry
+# ==========================================
+process.load("Alignment.CommonAlignmentProducer.FakeAlignmentSource_cfi")
+process.preferFakeAlign = cms.ESPrefer("FakeAlignmentSource")
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
+
+process.analyzer1 = cms.EDAnalyzer("MakeEMTFAngleLUT",
+    # Verbosity level
+    verbosity = cms.untracked.int32(1),
+
+    # Output file
+    outfile = cms.string("angle.root"),
+)
+
+process.path1 = cms.Path(process.analyzer1)

--- a/L1TMuonEndCap/test/unittests/TestEMTFPhiMemoryImage.cpp
+++ b/L1TMuonEndCap/test/unittests/TestEMTFPhiMemoryImage.cpp
@@ -10,6 +10,7 @@ class TestEMTFPhiMemoryImage: public CppUnit::TestFixture
   CPPUNIT_TEST(test_bitset);
   CPPUNIT_TEST(test_rotation);
   CPPUNIT_TEST(test_out_of_range);
+  CPPUNIT_TEST(test_z130);
   CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -21,6 +22,7 @@ public:
   void test_bitset();
   void test_rotation();
   void test_out_of_range();
+  void test_z130();
 };
 
 ///registration of the test so that the runner can find it
@@ -135,4 +137,39 @@ void TestEMTFPhiMemoryImage::test_out_of_range()
   CPPUNIT_ASSERT_THROW(image.get_word(1, 4), std::out_of_range);
   CPPUNIT_ASSERT_THROW(image.set_bit(5, 0), std::out_of_range);
   CPPUNIT_ASSERT_THROW(image.test_bit(5, 4), std::out_of_range);
+}
+
+void TestEMTFPhiMemoryImage::test_z130()
+{
+  EMTFPhiMemoryImage image;
+  EMTFPhiMemoryImage pattern;
+
+  // Set pattern
+  int i = 0;
+  pattern.set_straightness(0);
+
+  for (i = 0; i <= 7; ++i)
+    pattern.set_bit(0, i);
+  for (i = 7+8; i <= 7+8; ++i)
+    pattern.set_bit(1, i);
+  for (i = 7+8; i <= 14+8; ++i)
+    pattern.set_bit(2, i);
+  for (i = 7+8; i <= 14+8; ++i)
+    pattern.set_bit(3, i);
+  pattern.rotr(8);
+
+  // Set image
+  image.set_bit(0, 115);
+  image.set_bit(1, 133);
+  image.set_bit(2, 136);
+  image.set_bit(3, 131);
+  image.rotl(7);
+  image.rotr(130);
+
+  int code = pattern.op_and(image);  // AND operation
+
+  //std::cout << "pattern:\n" << pattern << std::endl;
+  //std::cout << "image:\n" << image << std::endl;
+  //std::cout << "code: " << code << std::endl;
+  CPPUNIT_ASSERT_EQUAL(code, 0b101);
 }

--- a/L1TMuonEndCap/test/unittests/pippo_cfg.py
+++ b/L1TMuonEndCap/test/unittests/pippo_cfg.py
@@ -42,6 +42,7 @@ process.options = cms.untracked.PSet()
 
 # GlobalTag
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data', '')


### PR DESCRIPTION
This PR contains the necessary fixes to bring the data-emulator agreement to >99.5%. It includes:
- Implementation of FW sorting for CSC hits
- Implementation of ME1/1 theta duplication in FW
- Minor fixes like ME1/1 theta initialization bug, precise theta assignment, zone numbering, etc
- Additional options like 'BugSameSectorPt0'

This PR should be merged after PR #16.

This PR should close issue #12.