### PR TITLE
Emulate Alex's firmware implementation with RPC hits

### DIFF
--- a/L1TMuonEndCap/python/simEmtfDigis_cfi.py
+++ b/L1TMuonEndCap/python/simEmtfDigis_cfi.py
@@ -17,7 +17,7 @@ simEmtfDigisMC = cms.EDProducer("L1TMuonEndCapTrackProducer",
 
     # Run with CSC, RPC
     CSCEnable = cms.bool(True),
-    RPCEnable = cms.bool(False),
+    RPCEnable = cms.bool(True),
 
     # BX
     MinBX    = cms.int32(-3),
@@ -75,7 +75,7 @@ simEmtfDigisMC = cms.EDProducer("L1TMuonEndCapTrackProducer",
 
     # Sector processor track-building parameters
     spTBParams16 = cms.PSet(
-        ThetaWindow    = cms.int32(4),
+        ThetaWindow    = cms.int32(8),
         ThetaWindowRPC = cms.int32(8),
         BugME11Dupes   = cms.bool(False),
     ),

--- a/L1TMuonEndCap/src/AngleCalculation.cc
+++ b/L1TMuonEndCap/src/AngleCalculation.cc
@@ -139,7 +139,7 @@ void AngleCalculation::calculate_angles(EMTFTrack& track) const {
       for (const auto& conv_hitA : conv_hitsA) {
         for (const auto& conv_hitB : conv_hitsB) {
           // Has RPC?
-          bool has_rpc = (conv_hitA.Subsystem() == TriggerPrimitive::kRPC || conv_hitB.Subsystem() == TriggerPrimitive::kRPC);
+          //bool has_rpc = (conv_hitA.Subsystem() == TriggerPrimitive::kRPC || conv_hitB.Subsystem() == TriggerPrimitive::kRPC);
 
           // Calculate theta deltas
           int thA = conv_hitA.Theta_fp();
@@ -153,7 +153,7 @@ void AngleCalculation::calculate_angles(EMTFTrack& track) const {
             best_dtheta_arr.at(ipair) = dth;
             best_dtheta_sign_arr.at(ipair) = dth_sign;
             best_dtheta_valid_arr.at(ipair) = true;
-            best_has_rpc_arr.at(ipair) = has_rpc;
+            //best_has_rpc_arr.at(ipair) = has_rpc;  // FW doesn't check whether a segment is CSC or RPC
 
             // first 3 pairs, use station B
             // last 3 pairs, use station A
@@ -359,7 +359,7 @@ void AngleCalculation::calculate_angles(EMTFTrack& track) const {
 
   for (int i = 0; i < NUM_STATIONS; ++i) {
     const auto& v = st_conv_hits.at(i);
-    ptlut_data.cpattern[i] = v.empty() ? 0 : v.front().Pattern();  // Automatically 10 for RPCs
+    ptlut_data.cpattern[i] = v.empty() ? 0 : v.front().Pattern();  // Automatically set to 0 for RPCs
     ptlut_data.fr[i]       = v.empty() ? 0 : isFront(v.front().Station(), v.front().Ring(), v.front().Chamber(), v.front().Subsystem());
   }
 

--- a/L1TMuonEndCap/src/BestTrackSelection.cc
+++ b/L1TMuonEndCap/src/BestTrackSelection.cc
@@ -105,11 +105,11 @@ void BestTrackSelection::cancel_one_bx(
         assert(conv_hit.Valid());
 
         // A segment identifier (chamber, strip, bx)
-        //const segment_ref_t segment = {{conv_hit.PC_station()*9 + conv_hit.PC_chamber(), conv_hit.Strip(), 0}};
-        int chamber_index  = int(conv_hit.Subsystem() == TriggerPrimitive::kRPC)*9*5;
-        chamber_index     += conv_hit.PC_station()*9;
-        chamber_index     += conv_hit.PC_chamber();
-        const segment_ref_t segment = {{chamber_index, conv_hit.Strip(), 0}};
+        const segment_ref_t segment = {{conv_hit.PC_station()*9 + conv_hit.PC_chamber(), conv_hit.Strip(), 0}};  // FW doesn't check whether a segment is CSC or RPC
+        //int chamber_index  = int(conv_hit.Subsystem() == TriggerPrimitive::kRPC)*9*5;
+        //chamber_index     += conv_hit.PC_station()*9;
+        //chamber_index     += conv_hit.PC_chamber();
+        //const segment_ref_t segment = {{chamber_index, conv_hit.Strip(), 0}};
         segments.at(zn).push_back(segment);
       }
     }  // end loop over n
@@ -301,12 +301,22 @@ void BestTrackSelection::cancel_multi_bx(
         for (const auto& conv_hit : track.Hits()) {
           assert(conv_hit.Valid());
 
+          // Notes from Alex (2017-03-16):
+          //
+          //     What happens currently is that RPC hits are inserted instead of
+          // CSC hits, if CSC hits are missing. So the track address will point
+          // at a CSC chamber, but the actual hit may have come from
+          // corresponding RPC located behind it. If the same substitution
+          // happened in the neighboring sector, then the cancellation in uGMT
+          // will work correctly. If the substitution happened in only one
+          // sector, then RPC hit may "trump" a CSC hit, or vice versa.
+
           // A segment identifier (chamber, strip, bx)
-          //const segment_ref_t segment = {{conv_hit.PC_station()*9 + conv_hit.PC_chamber(), conv_hit.Strip(), conv_hit.BX()}};
-          int chamber_index  = int(conv_hit.Subsystem() == TriggerPrimitive::kRPC)*9*5;
-          chamber_index     += conv_hit.PC_station()*9;
-          chamber_index     += conv_hit.PC_chamber();
-          const segment_ref_t segment = {{chamber_index, conv_hit.Strip(), conv_hit.BX()}};
+          const segment_ref_t segment = {{conv_hit.PC_station()*9 + conv_hit.PC_chamber(), conv_hit.Strip(), conv_hit.BX()}};  // FW doesn't check whether a segment is CSC or RPC
+          //int chamber_index  = int(conv_hit.Subsystem() == TriggerPrimitive::kRPC)*9*5;
+          //chamber_index     += conv_hit.PC_station()*9;
+          //chamber_index     += conv_hit.PC_chamber();
+          //const segment_ref_t segment = {{chamber_index, conv_hit.Strip(), conv_hit.BX()}};
           segments.at(hzn).push_back(segment);
         }
       }  // end loop over n

--- a/L1TMuonEndCap/src/PatternRecognition.cc
+++ b/L1TMuonEndCap/src/PatternRecognition.cc
@@ -189,13 +189,27 @@ void PatternRecognition::process(
   if (verbose_ > 0) {  // debug
     for (const auto& conv_hits : extended_conv_hits) {
       for (const auto& conv_hit : conv_hits) {
-        std::cout << "st: " << conv_hit.PC_station() << " ch: " << conv_hit.PC_chamber()
-            << " ph: " << conv_hit.Phi_fp() << " th: " << conv_hit.Theta_fp()
-            << " ph_hit: " << (1ul<<conv_hit.Ph_hit()) << " phzvl: " << conv_hit.Phzvl()
-            << " strip: " << conv_hit.Strip() << " wire: " << conv_hit.Wire() << " cpat: " << conv_hit.Pattern()
-            << " zone_hit: " << conv_hit.Zone_hit() << " zone_code: " << conv_hit.Zone_code()
-            << " bx: " << conv_hit.BX()
-            << std::endl;
+        if (conv_hit.Subsystem() == TriggerPrimitive::kCSC) {
+          std::cout << "st: " << conv_hit.PC_station() << " ch: " << conv_hit.PC_chamber()
+              << " ph: " << conv_hit.Phi_fp() << " th: " << conv_hit.Theta_fp()
+              << " ph_hit: " << (1ul<<conv_hit.Ph_hit()) << " phzvl: " << conv_hit.Phzvl()
+              << " strip: " << conv_hit.Strip() << " wire: " << conv_hit.Wire() << " cpat: " << conv_hit.Pattern()
+              << " zone_hit: " << conv_hit.Zone_hit() << " zone_code: " << conv_hit.Zone_code()
+              << " bx: " << conv_hit.BX()
+              << std::endl;
+        }
+      }
+    }
+
+    for (const auto& conv_hits : extended_conv_hits) {
+      for (const auto& conv_hit : conv_hits) {
+        if (conv_hit.Subsystem() == TriggerPrimitive::kRPC) {
+          std::cout << "RPC hit st: " << conv_hit.PC_station() << " ch: " << conv_hit.PC_chamber()
+              << " ph>>2: " << (conv_hit.Phi_fp()>>2) << " th>>2: " << (conv_hit.Theta_fp()>>2)
+              << " strip: " << conv_hit.Strip() << " roll: " << conv_hit.Roll() << " cpat: " << conv_hit.Pattern()
+              << " bx: " << conv_hit.BX()
+              << std::endl;
+        }
       }
     }
   }
@@ -215,7 +229,7 @@ void PatternRecognition::process(
     process_single_zone(izone+1, zone_images.at(izone), patt_lifetime_map, zone_roads.at(izone));
   }
 
-  if (verbose_ > 1) {  // debug
+  if (verbose_ > 2) {  // debug
     for (int izone = NUM_ZONES; izone >= 1; --izone) {
       std::cout << "zone: " << izone << std::endl;
       std::cout << zone_images.at(izone-1) << std::endl;

--- a/L1TMuonEndCap/src/PrimitiveConversion.cc
+++ b/L1TMuonEndCap/src/PrimitiveConversion.cc
@@ -90,12 +90,11 @@ void PrimitiveConversion::process(
 
   for (; map_tp_it != map_tp_end; ++map_tp_it) {
     int selected   = map_tp_it->first;
-    // Try to match the definitions used for CSC primitive conversion (unconfirmed!)
+    // RPC chambers have been mapped to CSC chambers
     int pc_sector  = sector_;
-    int pc_station = (selected < 12 ? (selected / 6) + 1 : (selected / 12) + 2);  // {1, 5} = {RE1, RE2, RE3, RE4, neighbor}
-    if (pc_station == 1)  pc_station = 0;  // because CSC pc_station 0 has neighbor, but pc_station 1 has no neighbor
-    int pc_chamber = (selected < 12 ? (selected % 6) : (selected % 12));  // Unique identifier per station
-    int pc_segment = 0;
+    int pc_station = selected / 9;  // {0, 5} = {ME1 sub 1, ME1 sub 2, ME2, ME3, ME4, neighbor}
+    int pc_chamber = selected % 9;  // Equals CSC ID - 1 for all except neighbor chambers
+    int pc_segment = 0;             // Counts hits in a single chamber
 
     TriggerPrimitiveCollection::const_iterator tp_it  = map_tp_it->second.begin();
     TriggerPrimitiveCollection::const_iterator tp_end = map_tp_it->second.end();

--- a/L1TMuonEndCap/src/PrimitiveSelection.cc
+++ b/L1TMuonEndCap/src/PrimitiveSelection.cc
@@ -9,7 +9,7 @@
 #define NUM_CSC_CHAMBERS 6*9   // 18 in ME1; 9 in ME2,3,4; 9 from neighbor sector.
                                // Arranged in FW as 6 stations, 9 chambers per station
 #define NUM_RPC_CHAMBERS 7*6   // 6 in RE1,2; 12 in RE3,4; 6 from neighbor sector.
-                               // Arranged in FW as 7 stations, 6 chambers per station (unconfirmed!)
+                               // Arranged in FW as 7 stations, 6 chambers per station
 
 using CSCData = TriggerPrimitive::CSCData;
 using RPCData = TriggerPrimitive::RPCData;
@@ -242,6 +242,68 @@ void PrimitiveSelection::process(
 
     }  // end loop over selected_rpc_map
   }  // end if do_clustering
+
+  // Map RPC subsector and chamber to CSC chambers
+  bool map_rpc_to_csc = true;
+  if (map_rpc_to_csc) {
+    std::map<int, TriggerPrimitiveCollection> tmp_selected_rpc_map;
+
+    std::map<int, TriggerPrimitiveCollection>::iterator map_tp_it  = selected_rpc_map.begin();
+    std::map<int, TriggerPrimitiveCollection>::iterator map_tp_end = selected_rpc_map.end();
+
+    for (; map_tp_it != map_tp_end; ++map_tp_it) {
+      int selected = map_tp_it->first;
+      TriggerPrimitiveCollection& tmp_primitives = map_tp_it->second;  // pass by reference
+      assert(tmp_primitives.size() <= 2);  // at most 2
+
+      int rpc_sub = selected / 6;
+      int rpc_chm = selected % 6;
+
+      int pc_station = -1;
+      int pc_chamber = -1;
+
+      if (rpc_sub != 6) {  // native
+        if (rpc_chm == 0) {  // RE1/2
+          if (0 <= rpc_sub && rpc_sub < 3) {
+            pc_station = 0;
+            pc_chamber = 3 + rpc_sub;
+          } else if (3 <= rpc_sub && rpc_sub < 6) {
+            pc_station = 1;
+            pc_chamber = 3 + (rpc_sub - 3);
+          }
+        } else if (rpc_chm == 1) {  // RE2/2
+           pc_station = 2;
+           pc_chamber = 3 + rpc_sub;
+        } else if (2 <= rpc_chm && rpc_chm <= 3) {  // RE3/2, RE3/3
+           pc_station = 3;
+           pc_chamber = 3 + rpc_sub;
+        } else if (4 <= rpc_chm && rpc_chm <= 5) {  // RE4/2, RE4/3
+           pc_station = 4;
+           pc_chamber = 3 + rpc_sub;
+        }
+
+      } else {  // neighbor
+         pc_station = 5;
+         if (rpc_chm == 0) {  // RE1/2
+           pc_chamber = 1;
+         } else if (rpc_chm == 1) {  // RE2/2
+           pc_chamber = 4;
+         } else if (2 <= rpc_chm && rpc_chm <= 3) {  // RE3/2, RE3/3
+           pc_chamber = 6;
+         } else if (4 <= rpc_chm && rpc_chm <= 5) {  // RE4/2, RE4/3
+           pc_chamber = 8;
+         }
+      }
+
+      assert(pc_station != -1 && pc_chamber != -1);
+
+      selected = (pc_station * 9) + pc_chamber;
+
+      tmp_selected_rpc_map[selected] = tmp_primitives;
+    }  // end loop over selected_rpc_map
+
+    std::swap(selected_rpc_map, tmp_selected_rpc_map);
+  }  // end if map_rpc_to_csc
 }
 
 // _____________________________________________________________________________
@@ -418,20 +480,33 @@ bool PrimitiveSelection::is_in_bx_rpc(int tp_bx) const {
 int PrimitiveSelection::get_index_rpc(int tp_station, int tp_ring, int tp_subsector, bool is_neighbor) const {
   int selected = -1;
 
-  if (!is_neighbor) {
-    if (tp_station <= 2) {  // RE1:  0 -  5, RE2:  6 - 11
-      selected = ((tp_station - 1)*6) + ((tp_subsector + 3) % 6);
-    } else {                // RE3: 12 - 23, RE4: 24 - 35
-      selected = (2)*6 + ((tp_station - 3)*12) + ((tp_ring - 2)*6) + ((tp_subsector + 3) % 6);
-    }
+  // CPPF RX data come in 3 frames x 64 bits, for 7 links. Each 64-bit data
+  // carry 2 words of 32 bits. Each word carries phi (11 bits) and theta (5 bits)
+  // of 2 segments (x2).
+  //
+  // Firmware uses 'rpc_sub' as RPC subsector index and 'rpc_chm' as RPC chamber index
+  // rpc_ch  [0,6] = RPC subsector 3, 4, 5, 6, 1 from neighbor, 2 from neighbor, 2. They correspond to
+  //                 CSC sector phi 0-10 deg, 10-20, 20-30, 30-40, 40-50, 50-60, 50-60 from neighbor
+  // rpc_chm [0,5] = RPC chamber RE1/2, RE2/2, RE3/2, RE3/3, RE4/2, RE4/3
+  //
 
+  int rpc_sub = -1;
+  int rpc_chm = -1;
+
+  if (!is_neighbor) {
+    rpc_sub = ((tp_subsector + 3) % 6);
   } else {
-    if (tp_station <= 2) {  // RE1: 36       RE2: 37
-      selected = (2)*6 + (2)*12 + (tp_station - 1);
-    } else {                // RE3: 38 - 39, RE4: 40 - 41
-      selected = (2)*6 + (2)*12 + (1)*2 + ((tp_station - 3)*2) + (tp_ring - 2);
-    }
+    rpc_sub = 6;
   }
 
+  if (tp_station <= 2) {
+    rpc_chm = (tp_station - 1);
+  } else {
+    rpc_chm = 2 + (tp_station - 3)*2 + (tp_ring - 2);
+  }
+
+  assert(rpc_sub != -1 && rpc_chm != -1);
+
+  selected = (rpc_sub * 6) + rpc_chm;
   return selected;
 }

--- a/L1TMuonEndCap/src/PtAssignment.cc
+++ b/L1TMuonEndCap/src/PtAssignment.cc
@@ -56,8 +56,9 @@ void PtAssignment::process(
 
     int gmt_eta = aux().getGMTEta(track.Theta_fp(), track.Endcap());  // Convert to integer eta using FW LUT
 
-    // Explanation from Alex:
-    // When using two's complement, you get two eta bins with zero coordinate.
+    // Notes from Alex (2016-09-28):
+    //
+    //     When using two's complement, you get two eta bins with zero coordinate.
     // This peculiarity is created because positive and negative endcaps are
     // processed by separate processors, so each of them gets its own zero bin.
     // With simple inversion, the eta scale becomes uniform, one bin for one

--- a/L1TMuonEndCap/src/TrackFinder.cc
+++ b/L1TMuonEndCap/src/TrackFinder.cc
@@ -149,33 +149,95 @@ void TrackFinder::process(
   }
 
   if (verbose_ > 0) {  // debug
-    std::cout << "Num of EMTFHit: " << out_hits.size() << std::endl;
-    std::cout << "bx e s ss st vf ql cp wg id bd hs" << std::endl;
-    for (const auto& h : out_hits) {
-      int bx      = h.BX() + 3;
-      int sector  = h.PC_sector();
-      int station = (h.PC_station() == 0 && h.Subsector() == 1) ? 1 : h.PC_station();
-      int chamber = h.PC_chamber() + 1;
-      int strip   = (h.Station() == 1 && h.Ring() == 4) ? h.Strip() + 128 : h.Strip();  // ME1/1a
-      std::cout << bx << " " << h.Endcap() << " " << sector << " " << h.Subsector() << " "
-          << station << " " << h.Valid() << " " << h.Quality() << " " << h.Pattern() << " "
-          << h.Wire() << " " << chamber << " " << h.Bend() << " " << strip << std::endl;
-    }
 
-    std::cout << "Converted hits: " << std::endl;
-    std::cout << "st ch ph th ph_hit phzvl" << std::endl;
-    for (const auto& h : out_hits) {
-      std::cout << h.PC_station() << " " << h.PC_chamber() << " " << h.Phi_fp() << " " << h.Theta_fp() << " "
-          << (1ul<<h.Ph_hit()) << " " << h.Phzvl() << std::endl;
-    }
+    for (int endcap = MIN_ENDCAP; endcap <= MAX_ENDCAP; ++endcap) {
+      for (int sector = MIN_TRIGSECTOR; sector <= MAX_TRIGSECTOR; ++sector) {
+        const int es = (endcap - MIN_ENDCAP) * (MAX_TRIGSECTOR - MIN_TRIGSECTOR + 1) + (sector - MIN_TRIGSECTOR);
 
-    std::cout << "Num of EMTFTrack: " << out_tracks.size() << std::endl;
-    std::cout << "bx e s a mo et ph cr q pt" << std::endl;
-    for (const auto& t : out_tracks) {
-      std::cout << t.BX() << " " << t.Endcap() << " " << t.Sector() << " " << t.PtLUT().address << " " << t.Mode() << " "
-          << t.GMT_eta() << " " << t.GMT_phi() << " " << t.GMT_charge() << " " << t.GMT_quality() << " " << t.Pt() << std::endl;
-    }
-  }
+        // _____________________________________________________________________
+        // This prints the hits as raw text input to the firmware simulator
+        // "12345" is the BX separator
+
+        std::cout << "==== Endcap " << endcap << " Sector " << sector << " Hits ====" << std::endl;
+        std::cout << "bx e s ss st vf ql cp wg id bd hs" << std::endl;
+
+        bool empty_sector = true;
+        for (const auto& h : out_hits) {
+          if (h.Sector_idx() != es)  continue;
+          empty_sector = false;
+        }
+
+        for (int ibx = -3-5; (ibx < +3+5+5) && !empty_sector; ++ibx) {
+
+          for (const auto& h : out_hits) {
+            if (h.Subsystem() == TriggerPrimitive::kCSC) {
+              if (h.Sector_idx() != es)  continue;
+              if (h.BX() != ibx)  continue;
+
+              int bx        = 1;
+              int endcap    = (h.Endcap() == 1) ? 1 : 2;
+              int sector    = h.PC_sector();
+              int station   = (h.PC_station() == 0 && h.Subsector() == 1) ? 1 : h.PC_station();
+              int chamber   = h.PC_chamber() + 1;
+              int strip     = (h.Station() == 1 && h.Ring() == 4) ? h.Strip() + 128 : h.Strip();  // ME1/1a
+              int wire      = h.Wire();
+              int valid     = 1;
+              std::cout << bx << " " << endcap << " " << sector << " " << h.Subsector() << " "
+                  << station << " " << valid << " " << h.Quality() << " " << h.Pattern() << " "
+                  << wire << " " << chamber << " " << h.Bend() << " " << strip << std::endl;
+
+            } else if (h.Subsystem() == TriggerPrimitive::kRPC) {
+              if (h.Sector_idx() != es)  continue;
+              if (h.BX()+5 != ibx)  continue;  // RPC hits should be supplied 5 BX later relative to CSC hits
+
+              // Assign RPC link index. Code taken from src/PrimitiveSelection.cc
+              int rpc_sub = -1;
+              int rpc_chm = -1;
+              if (!h.Neighbor()) {
+                rpc_sub = ((h.Subsector() + 3) % 6);
+              } else {
+                rpc_sub = 6;
+              }
+              if (h.Station() <= 2) {
+                rpc_chm = (h.Station() - 1);
+              } else {
+                rpc_chm = 2 + (h.Station() - 3)*2 + (h.Ring() - 2);
+              }
+
+              int bx        = 1;
+              int endcap    = (h.Endcap() == 1) ? 1 : 2;
+              int sector    = h.PC_sector();
+              int station   = rpc_sub;
+              int chamber   = rpc_chm + 1;
+              int strip     = (h.Phi_fp() >> 2);
+              int wire      = (h.Theta_fp() >> 2);
+              int valid     = 2;  // this marks RPC stub
+              std::cout << bx << " " << endcap << " " << sector << " " << 0 << " "
+                  << station << " " << valid << " " << 0 << " " << 0 << " "
+                  << wire << " " << chamber << " " << 0 << " " << strip << std::endl;
+            }
+          }  // end loop over hits
+
+          std::cout << "12345" << std::endl;
+        }  // end loop over bx
+
+        // _____________________________________________________________________
+        // This prints the tracks as raw text output from the firmware simulator
+
+        std::cout << "==== Endcap " << endcap << " Sector " << sector << " Tracks ====" << std::endl;
+        std::cout << "bx e s a mo et ph cr q pt" << std::endl;
+
+        for (const auto& t : out_tracks) {
+          if (t.Sector_idx() != es)  continue;
+
+          std::cout << t.BX() << " " << (t.Endcap() == 1 ? 1 : 2) << " " << t.Sector() << " " << t.PtLUT().address << " " << t.Mode() << " "
+              << (t.GMT_eta() >= 0 ? t.GMT_eta() : t.GMT_eta()+512)<< " " << t.GMT_phi() << " "
+              << t.GMT_charge() << " " << t.GMT_quality() << " " << t.Pt() << std::endl;
+        }  // end loop over tracks
+
+      }  // end loop over sector
+    }  // end loop over endcap
+  }  // end debug
 
   return;
 }


### PR DESCRIPTION
This PR implements the actual RPC hit inclusion logic as implemented in Alex's firmware dated 2017-04-03.

Notes:

- Default 'RPCEnable' is turned on.
- Default 'ThetaWindow' is set to 4.
- CLCT pattern for RPC hits is set to 0 as in FW, instead of 10.
- RE3/2 & RE3/3 are considered as one chamber; RE4/2 & RE4/3 too. (Because CSC don't have ring 3 in stations 3 & 4.)
- Internal variables for RPC hits such as `pc_station`, `pc_chamber`, `pc_segment`, etc have been updated.

I compared the emulator vs Modelsim outputs for 6 events and they matched bit-wise.