### PR TITLE
Include GEM hits in EMTF for Phase 2 studies (preliminary)

### DIFF
--- a/L1TMuonEndCap/BuildFile.xml
+++ b/L1TMuonEndCap/BuildFile.xml
@@ -6,15 +6,12 @@
 
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
-<use name="DataFormats/CSCDigi"/>
-<use name="DataFormats/RPCDigi"/>
-<use name="DataFormats/DTDigi"/>
-<use name="DataFormats/L1DTTrackFinder"/>
-<use name="DataFormats/L1TMuon"/>
 
+<use name="DataFormats/L1TMuon"/>
 <use name="Geometry/DTGeometry"/>
 <use name="Geometry/RPCGeometry"/>
 <use name="Geometry/CSCGeometry"/>
+<use name="Geometry/GEMGeometry"/>
 <use name="L1Trigger/DTUtilities"/>
 <use name="L1Trigger/CSCCommonTrigger"/>
 <use name="MagneticField/Engine"/>

--- a/L1TMuonEndCap/interface/Common.hh
+++ b/L1TMuonEndCap/interface/Common.hh
@@ -26,10 +26,18 @@ typedef L1TMuonEndCap::GeometryTranslator         GeometryTranslator;
 typedef L1TMuonEndCap::TriggerPrimitive           TriggerPrimitive;
 typedef L1TMuonEndCap::TriggerPrimitiveCollection TriggerPrimitiveCollection;
 
+typedef TriggerPrimitive::CSCData CSCData;
+typedef TriggerPrimitive::RPCData RPCData;
+typedef TriggerPrimitive::GEMData GEMData;
+
 typedef emtf::CSCTag CSCTag;
 typedef emtf::RPCTag RPCTag;
+typedef emtf::GEMTag GEMTag;
 
 // Constants
+
+// Phase 2 Geometry a.k.a. HL-LHC
+#define PHASE_TWO_GEOMETRY 0
 
 // from DataFormats/MuonDetId/interface/CSCDetId.h
 #define MIN_ENDCAP 1

--- a/L1TMuonEndCap/interface/EMTFSubsystemTag.hh
+++ b/L1TMuonEndCap/interface/EMTFSubsystemTag.hh
@@ -5,6 +5,8 @@
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiCollection.h"
 #include "DataFormats/RPCDigi/interface/RPCDigi.h"
 #include "DataFormats/RPCDigi/interface/RPCDigiCollection.h"
+#include "DataFormats/GEMDigi/interface/GEMPadDigi.h"
+#include "DataFormats/GEMDigi/interface/GEMPadDigiCollection.h"
 
 
 namespace emtf {
@@ -17,6 +19,11 @@ namespace emtf {
   struct RPCTag {
     typedef RPCDigi           digi_type;
     typedef RPCDigiCollection digi_collection;
+  };
+
+  struct GEMTag {
+    typedef GEMPadDigi           digi_type;
+    typedef GEMPadDigiCollection digi_collection;
   };
 
 }  //  namespace emtf

--- a/L1TMuonEndCap/interface/GeometryTranslator.h
+++ b/L1TMuonEndCap/interface/GeometryTranslator.h
@@ -25,6 +25,7 @@ namespace edm {
   class EventSetup;
 }
 
+class GEMGeometry;
 class RPCGeometry;
 class CSCGeometry;
 class CSCLayer;
@@ -47,6 +48,7 @@ namespace L1TMuonEndCap {
 
     void checkAndUpdateGeometry(const edm::EventSetup&);
 
+    const GEMGeometry& getGEMGeometry() const { return *_geogem; }
     const RPCGeometry& getRPCGeometry() const { return *_georpc; }
     const CSCGeometry& getCSCGeometry() const { return *_geocsc; }
     const DTGeometry&  getDTGeometry()  const { return *_geodt;  }
@@ -56,12 +58,18 @@ namespace L1TMuonEndCap {
   private:
     // pointers to the current geometry records
     unsigned long long _geom_cache_id;
+    edm::ESHandle<GEMGeometry> _geogem;
     edm::ESHandle<RPCGeometry> _georpc;
     edm::ESHandle<CSCGeometry> _geocsc;
     edm::ESHandle<DTGeometry>  _geodt;
 
     unsigned long long _magfield_cache_id;
     edm::ESHandle<MagneticField> _magfield;
+
+    GlobalPoint getGEMSpecificPoint(const TriggerPrimitive&) const;
+    double calcGEMSpecificEta(const TriggerPrimitive&) const;
+    double calcGEMSpecificPhi(const TriggerPrimitive&) const;
+    double calcGEMSpecificBend(const TriggerPrimitive&) const;
 
     GlobalPoint getRPCSpecificPoint(const TriggerPrimitive&) const;
     double calcRPCSpecificEta(const TriggerPrimitive&) const;

--- a/L1TMuonEndCap/interface/MuonTriggerPrimitive.h
+++ b/L1TMuonEndCap/interface/MuonTriggerPrimitive.h
@@ -39,13 +39,17 @@ class CSCDetId;
 class RPCDigiL1Link;
 class RPCDetId;
 
+// GEM digi types
+class GEMPadDigi;
+class GEMDetId;
+
 
 namespace L1TMuonEndCap {
 
   class TriggerPrimitive {
   public:
     // define the subsystems that we have available
-    enum subsystem_type{kDT,kCSC,kRPC,kNSubsystems};
+    enum subsystem_type{kDT,kCSC,kRPC,kGEM,kNSubsystems};
 
     // define the data we save locally from each subsystem type
     // variables in these structs keep their colloquial meaning
@@ -54,8 +58,8 @@ namespace L1TMuonEndCap {
     struct RPCData {
       RPCData() : strip(0), strip_low(0), strip_hi(0), layer(0), bx(0) {}
       uint16_t strip;
-      uint16_t strip_low;
-      uint16_t strip_hi;
+      uint16_t strip_low; // for use in clustering
+      uint16_t strip_hi;  // for use in clustering
       uint16_t layer;
       int16_t bx;
     };
@@ -105,6 +109,14 @@ namespace L1TMuonEndCap {
       int theta_quality;
     };
 
+    struct GEMData {
+      GEMData() : pad(0), pad_low(0), pad_hi(0), bx(0) {}
+      uint16_t pad;
+      uint16_t pad_low; // for use in clustering
+      uint16_t pad_hi;  // for use in clustering
+      int16_t bx;
+    };
+
     //Persistency
     TriggerPrimitive(): _subsystem(kNSubsystems) {}
 
@@ -127,6 +139,10 @@ namespace L1TMuonEndCap {
                      const unsigned strip,
                      const unsigned layer,
                      const int bx);
+
+    // GEM
+    TriggerPrimitive(const GEMDetId& detid,
+                     const GEMPadDigi& digi);
 
     //copy
     TriggerPrimitive(const TriggerPrimitive&);
@@ -161,14 +177,17 @@ namespace L1TMuonEndCap {
     void setDTData(const DTData& dt) { _dt = dt; }
     void setCSCData(const CSCData& csc) { _csc = csc; }
     void setRPCData(const RPCData& rpc) { _rpc = rpc; }
+    void setGEMData(const GEMData& gem) { _gem = gem; }
 
     const DTData  getDTData()  const { return _dt;  }
     const CSCData getCSCData() const { return _csc; }
     const RPCData getRPCData() const { return _rpc; }
+    const GEMData getGEMData() const { return _gem; }
 
     DTData&  accessDTData()  { return _dt; }
     CSCData& accessCSCData() { return _csc; }
     RPCData& accessRPCData() { return _rpc; }
+    GEMData& accessGEMData() { return _gem; }
 
     // consistent accessors to common information
     const int getBX() const;
@@ -176,7 +195,6 @@ namespace L1TMuonEndCap {
     const int getWire() const;
     const int getPattern() const;
     const DetId rawId() const {return _id;};
-    const int Id() const;
 
     const unsigned getGlobalSector() const { return _globalsector; }
     const unsigned getSubSector() const { return _subsector; }
@@ -195,10 +213,14 @@ namespace L1TMuonEndCap {
     void calculateRPCGlobalSector(const RPCDetId& chid,
                                   unsigned& global_sector,
                                   unsigned& subsector );
+    void calculateGEMGlobalSector(const GEMDetId& chid,
+                                  unsigned& global_sector,
+                                  unsigned& subsector );
 
     DTData  _dt;
     CSCData _csc;
     RPCData _rpc;
+    GEMData _gem;
 
     DetId _id;
 

--- a/L1TMuonEndCap/interface/PrimitiveConversion.hh
+++ b/L1TMuonEndCap/interface/PrimitiveConversion.hh
@@ -12,7 +12,7 @@ public:
       const GeometryTranslator* tp_geom,
       const SectorProcessorLUT* lut,
       int verbose, int endcap, int sector, int bx,
-      int bxShiftCSC, int bxShiftRPC,
+      int bxShiftCSC, int bxShiftRPC, int bxShiftGEM,
       const std::vector<int>& zoneBoundaries, int zoneOverlap, int zoneOverlapRPC,
       bool duplicateTheta, bool fixZonePhi, bool useNewZones, bool fixME11Edges,
       bool bugME11Dupes
@@ -25,7 +25,7 @@ public:
       EMTFHitCollection& conv_hits
   ) const;
 
-  const SectorProcessorLUT& lut() const;
+  const SectorProcessorLUT& lut() const { return *lut_; }
 
   // CSC functions
   void convert_csc(
@@ -33,6 +33,7 @@ public:
       const TriggerPrimitive& muon_primitive,
       EMTFHit& conv_hit
   ) const;
+
   void convert_csc_details(EMTFHit& conv_hit) const;
 
   // RPC functions
@@ -41,7 +42,18 @@ public:
       const TriggerPrimitive& muon_primitive,
       EMTFHit& conv_hit
   ) const;
+
   void convert_rpc_details(EMTFHit& conv_hit) const;
+
+  // GEM functions
+  void convert_gem(
+      int pc_sector, int pc_station, int pc_chamber, int pc_segment,
+      const TriggerPrimitive& muon_primitive,
+      EMTFHit& conv_hit
+  ) const;
+
+  void convert_gem_details(EMTFHit& conv_hit) const;
+
 
 private:
   const GeometryTranslator* tp_geom_;
@@ -50,7 +62,7 @@ private:
 
   int verbose_, endcap_, sector_, bx_;
 
-  int bxShiftCSC_, bxShiftRPC_;
+  int bxShiftCSC_, bxShiftRPC_, bxShiftGEM_;
 
   std::vector<int> zoneBoundaries_;
   int zoneOverlap_, zoneOverlapRPC_;

--- a/L1TMuonEndCap/interface/PrimitiveConversion.hh
+++ b/L1TMuonEndCap/interface/PrimitiveConversion.hh
@@ -52,6 +52,19 @@ public:
 
   void convert_gem_details(EMTFHit& conv_hit) const;
 
+  // Aux functions
+  int get_zone_code(const EMTFHit& conv_hit, int th) const;
+
+  int get_phzvl(const EMTFHit& conv_hit, int zone_code) const;
+
+  int get_fs_zone_code(const EMTFHit& conv_hit) const;
+
+  int get_fs_segment(const EMTFHit& conv_hit, int fw_station, int fw_cscid, int pc_segment) const;
+
+  int get_bt_station(const EMTFHit& conv_hit, int fw_station, int fw_cscid, int pc_segment) const;
+
+  int get_bt_segment(const EMTFHit& conv_hit, int fw_station, int fw_cscid, int pc_segment) const;
+
 
 private:
   const GeometryTranslator* tp_geom_;

--- a/L1TMuonEndCap/interface/PrimitiveConversion.hh
+++ b/L1TMuonEndCap/interface/PrimitiveConversion.hh
@@ -18,9 +18,7 @@ public:
       bool bugME11Dupes
   );
 
-  template<typename T>
   void process(
-      T tag,
       const std::map<int, TriggerPrimitiveCollection>& selected_prim_map,
       EMTFHitCollection& conv_hits
   ) const;

--- a/L1TMuonEndCap/interface/PrimitiveSelection.hh
+++ b/L1TMuonEndCap/interface/PrimitiveSelection.hh
@@ -20,6 +20,13 @@ public:
       std::map<int, TriggerPrimitiveCollection>& selected_prim_map
   ) const;
 
+  void merge(
+      std::map<int, TriggerPrimitiveCollection>& selected_csc_map,
+      std::map<int, TriggerPrimitiveCollection>& selected_rpc_map,
+      std::map<int, TriggerPrimitiveCollection>& selected_gem_map,
+      std::map<int, TriggerPrimitiveCollection>& selected_prim_map
+  ) const;
+
   // CSC functions
   // If selected, return an index 0-53, else return -1
   // The index 0-53 roughly corresponds to an input link. It maps to the
@@ -36,6 +43,8 @@ public:
   int get_index_csc(int tp_subsector, int tp_station, int tp_csc_ID, bool is_neighbor) const;
 
   // RPC functions
+  void cluster_rpc(const TriggerPrimitiveCollection& muon_primitives, TriggerPrimitiveCollection& clus_muon_primitives) const;
+
   int select_rpc(const TriggerPrimitive& muon_primitive) const;
 
   bool is_in_sector_rpc(int tp_endcap, int tp_sector, int tp_subsector) const;
@@ -47,6 +56,8 @@ public:
   int get_index_rpc(int tp_station, int tp_ring, int tp_subsector, bool is_neighbor) const;
 
   // GEM functions
+  void cluster_gem(const TriggerPrimitiveCollection& muon_primitives, TriggerPrimitiveCollection& clus_muon_primitives) const;
+
   int select_gem(const TriggerPrimitive& muon_primitive) const;
 
   bool is_in_sector_gem(int tp_endcap, int tp_sector) const;

--- a/L1TMuonEndCap/interface/PrimitiveSelection.hh
+++ b/L1TMuonEndCap/interface/PrimitiveSelection.hh
@@ -20,6 +20,7 @@ public:
       std::map<int, TriggerPrimitiveCollection>& selected_prim_map
   ) const;
 
+  // Put the hits from CSC, RPC, GEM together in one collection
   void merge(
       std::map<int, TriggerPrimitiveCollection>& selected_csc_map,
       std::map<int, TriggerPrimitiveCollection>& selected_rpc_map,

--- a/L1TMuonEndCap/interface/PrimitiveSelection.hh
+++ b/L1TMuonEndCap/interface/PrimitiveSelection.hh
@@ -49,13 +49,13 @@ public:
   // GEM functions
   int select_gem(const TriggerPrimitive& muon_primitive) const;
 
-  bool is_in_sector_gem(int tp_endcap, int tp_sector, int tp_subsector) const;
+  bool is_in_sector_gem(int tp_endcap, int tp_sector) const;
 
-  bool is_in_neighbor_sector_gem(int tp_endcap, int tp_sector, int tp_subsector) const;
+  bool is_in_neighbor_sector_gem(int tp_endcap, int tp_sector, int tp_subsector, int tp_station, int tp_csc_ID) const;
 
   bool is_in_bx_gem(int tp_bx) const;
 
-  int get_index_gem(int tp_station, int tp_ring, int tp_subsector, bool is_neighbor) const;
+  int get_index_gem(int tp_subsector, int tp_station, int tp_csc_ID, bool is_neighbor) const;
 
 
 private:

--- a/L1TMuonEndCap/interface/PrimitiveSelection.hh
+++ b/L1TMuonEndCap/interface/PrimitiveSelection.hh
@@ -8,7 +8,7 @@ class PrimitiveSelection {
 public:
   void configure(
       int verbose, int endcap, int sector, int bx,
-      int bxShiftCSC, int bxShiftRPC,
+      int bxShiftCSC, int bxShiftRPC, int bxShiftGEM,
       bool includeNeighbor, bool duplicateTheta,
       bool bugME11Dupes
   );
@@ -46,10 +46,22 @@ public:
 
   int get_index_rpc(int tp_station, int tp_ring, int tp_subsector, bool is_neighbor) const;
 
+  // GEM functions
+  int select_gem(const TriggerPrimitive& muon_primitive) const;
+
+  bool is_in_sector_gem(int tp_endcap, int tp_sector, int tp_subsector) const;
+
+  bool is_in_neighbor_sector_gem(int tp_endcap, int tp_sector, int tp_subsector) const;
+
+  bool is_in_bx_gem(int tp_bx) const;
+
+  int get_index_gem(int tp_station, int tp_ring, int tp_subsector, bool is_neighbor) const;
+
+
 private:
   int verbose_, endcap_, sector_, bx_;
 
-  int bxShiftCSC_, bxShiftRPC_;
+  int bxShiftCSC_, bxShiftRPC_, bxShiftGEM_;
 
   bool includeNeighbor_, duplicateTheta_;
 

--- a/L1TMuonEndCap/interface/SectorProcessor.hh
+++ b/L1TMuonEndCap/interface/SectorProcessor.hh
@@ -39,7 +39,7 @@ public:
       const SectorProcessorLUT* lut,
       const PtAssignmentEngine* pt_assign_engine,
       int verbose, int endcap, int sector,
-      int minBX, int maxBX, int bxWindow, int bxShiftCSC, int bxShiftRPC,
+      int minBX, int maxBX, int bxWindow, int bxShiftCSC, int bxShiftRPC, int bxShiftGEM,
       const std::vector<int>& zoneBoundaries, int zoneOverlap, int zoneOverlapRPC,
       bool includeNeighbor, bool duplicateTheta, bool fixZonePhi, bool useNewZones, bool fixME11Edges,
       const std::vector<std::string>& pattDefinitions, const std::vector<std::string>& symPattDefinitions, bool useSymPatterns,
@@ -81,7 +81,7 @@ private:
 
   int verbose_, endcap_, sector_;
 
-  int minBX_, maxBX_, bxWindow_, bxShiftCSC_, bxShiftRPC_;
+  int minBX_, maxBX_, bxWindow_, bxShiftCSC_, bxShiftRPC_, bxShiftGEM_;
 
   // For primitive conversion
   std::vector<int> zoneBoundaries_;

--- a/L1TMuonEndCap/interface/TrackFinder.hh
+++ b/L1TMuonEndCap/interface/TrackFinder.hh
@@ -40,11 +40,11 @@ private:
 
   const edm::ParameterSet config_;
 
-  const edm::EDGetToken tokenCSC_, tokenRPC_;
+  const edm::EDGetToken tokenCSC_, tokenRPC_, tokenGEM_;
 
   int verbose_;
 
-  bool useCSC_, useRPC_;
+  bool useCSC_, useRPC_, useGEM_;
 };
 
 #endif

--- a/L1TMuonEndCap/python/simEmtfDigis_cfi.py
+++ b/L1TMuonEndCap/python/simEmtfDigis_cfi.py
@@ -13,11 +13,12 @@ simEmtfDigisMC = cms.EDProducer("L1TMuonEndCapTrackProducer",
     # Input collections
     CSCInput = cms.InputTag('simCscTriggerPrimitiveDigis','MPCSORTED'),
     RPCInput = cms.InputTag('simMuonRPCDigis'),
-    #GEMInput = cms.InputTag('simMuonGEMPadDigis'),
+    GEMInput = cms.InputTag('simMuonGEMPadDigis'),
 
-    # Run with CSC, RPC
+    # Run with CSC, RPC, GEM
     CSCEnable = cms.bool(True),
     RPCEnable = cms.bool(True),
+    GEMEnable = cms.bool(False),
 
     # BX
     MinBX    = cms.int32(-3),
@@ -27,6 +28,7 @@ simEmtfDigisMC = cms.EDProducer("L1TMuonEndCapTrackProducer",
     # CSC LCT BX offset correction
     CSCInputBXShift = cms.int32(-6),
     RPCInputBXShift = cms.int32(0),
+    GEMInputBXShift = cms.int32(0),
 
     # Versioning
     Version      = cms.int32(1),
@@ -104,6 +106,7 @@ simEmtfDigisMC = cms.EDProducer("L1TMuonEndCapTrackProducer",
 simEmtfDigisData = simEmtfDigisMC.clone(
     CSCInput = cms.InputTag('emtfStage2Digis'),
     RPCInput = cms.InputTag('muonRPCDigis'),
+    GEMInput = cms.InputTag('muonGEMPadDigis'),
 )
 
 simEmtfDigis = simEmtfDigisMC.clone()

--- a/L1TMuonEndCap/src/AngleCalculation.cc
+++ b/L1TMuonEndCap/src/AngleCalculation.cc
@@ -330,6 +330,10 @@ void AngleCalculation::calculate_angles(EMTFTrack& track) const {
     if (subsystem == TriggerPrimitive::kRPC)
       return (station == 2);
 
+    // GEMs are in front of the CSCs
+    if (subsystem == TriggerPrimitive::kGEM)
+      return true;
+
     bool result = false;
     bool isOverlapping = !(station == 1 && ring == 3);
     // not overlapping means back

--- a/L1TMuonEndCap/src/EMTFSubsystemCollector.cc
+++ b/L1TMuonEndCap/src/EMTFSubsystemCollector.cc
@@ -54,3 +54,26 @@ void EMTFSubsystemCollector::extractPrimitives(
   }
   return;
 }
+
+// Specialized for GEM
+template<>
+void EMTFSubsystemCollector::extractPrimitives(
+    GEMTag tag, // Defined in interface/EMTFSubsystemTag.hh, maps to GEMPadDigi
+    const edm::Event& iEvent,
+    const edm::EDGetToken& token,
+    TriggerPrimitiveCollection& out
+) {
+  edm::Handle<GEMTag::digi_collection> gemDigis;
+  iEvent.getByToken(token, gemDigis);
+
+  auto chamber = gemDigis->begin();
+  auto chend   = gemDigis->end();
+  for( ; chamber != chend; ++chamber ) {
+    auto digi = (*chamber).second.first;
+    auto dend = (*chamber).second.second;
+    for( ; digi != dend; ++digi ) {
+      out.emplace_back((*chamber).first,*digi);
+    }
+  }
+  return;
+}

--- a/L1TMuonEndCap/src/PatternRecognition.cc
+++ b/L1TMuonEndCap/src/PatternRecognition.cc
@@ -177,6 +177,7 @@ void PatternRecognition::process(
     std::map<pattern_ref_t, int>& patt_lifetime_map,
     zone_array<EMTFRoadCollection>& zone_roads
 ) const {
+  // Exit if no hits
   int num_conv_hits = 0;
   for (const auto& conv_hits : extended_conv_hits)
     num_conv_hits += conv_hits.size();
@@ -212,7 +213,19 @@ void PatternRecognition::process(
         }
       }
     }
-  }
+
+    for (const auto& conv_hits : extended_conv_hits) {
+      for (const auto& conv_hit : conv_hits) {
+        if (conv_hit.Subsystem() == TriggerPrimitive::kGEM) {
+          std::cout << "GEM hit st: " << conv_hit.PC_station() << " ch: " << conv_hit.PC_chamber()
+              << " ph: " << conv_hit.Phi_fp() << " th: " << conv_hit.Theta_fp()
+              << " strip: " << conv_hit.Strip() << " roll: " << conv_hit.Roll() << " cpat: " << conv_hit.Pattern()
+              << " bx: " << conv_hit.BX()
+              << std::endl;
+        }
+      }
+    }
+  }  // end debug
 
   // Perform pattern recognition in each zone
   zone_array<PhiMemoryImage> zone_images;
@@ -275,7 +288,10 @@ bool PatternRecognition::is_zone_empty(
 
     for (; conv_hits_it != conv_hits_end; ++conv_hits_it) {
       if (conv_hits_it->Subsystem() == TriggerPrimitive::kRPC)
-        continue;  // Don't use RPCs for pattern formation
+        continue;  // Don't use RPC hits for pattern formation
+
+      if (conv_hits_it->Subsystem() == TriggerPrimitive::kGEM)
+        continue;  // Don't use GEM hits for pattern formation
 
       if (conv_hits_it->Zone_code() & (1 << izone)) {  // hit belongs to this zone
         num_conv_hits += 1;
@@ -311,7 +327,10 @@ void PatternRecognition::make_zone_image(
 
     for (; conv_hits_it != conv_hits_end; ++conv_hits_it) {
       if (conv_hits_it->Subsystem() == TriggerPrimitive::kRPC)
-        continue;  // Don't use RPCs for pattern formation
+        continue;  // Don't use RPC hits for pattern formation
+
+      if (conv_hits_it->Subsystem() == TriggerPrimitive::kGEM)
+        continue;  // Don't use GEM hits for pattern formation
 
       if (conv_hits_it->Zone_code() & (1 << izone)) {  // hit belongs to this zone
         unsigned int layer = conv_hits_it->Station() - 1;

--- a/L1TMuonEndCap/src/PrimitiveConversion.cc
+++ b/L1TMuonEndCap/src/PrimitiveConversion.cc
@@ -3,19 +3,17 @@
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
+#include "DataFormats/MuonDetId/interface/GEMDetId.h"
 
 #include "L1Trigger/L1TMuonEndCap/interface/SectorProcessorLUT.hh"
 #include "L1Trigger/L1TMuonEndCap/interface/TrackTools.hh"
-
-using CSCData = TriggerPrimitive::CSCData;
-using RPCData = TriggerPrimitive::RPCData;
 
 
 void PrimitiveConversion::configure(
     const GeometryTranslator* tp_geom,
     const SectorProcessorLUT* lut,
     int verbose, int endcap, int sector, int bx,
-    int bxShiftCSC, int bxShiftRPC,
+    int bxShiftCSC, int bxShiftRPC, int bxShiftGEM,
     const std::vector<int>& zoneBoundaries, int zoneOverlap, int zoneOverlapRPC,
     bool duplicateTheta, bool fixZonePhi, bool useNewZones, bool fixME11Edges,
     bool bugME11Dupes
@@ -33,6 +31,7 @@ void PrimitiveConversion::configure(
 
   bxShiftCSC_      = bxShiftCSC;
   bxShiftRPC_      = bxShiftRPC;
+  bxShiftGEM_      = bxShiftGEM;
 
   zoneBoundaries_  = zoneBoundaries;
   zoneOverlap_     = zoneOverlap;
@@ -45,7 +44,8 @@ void PrimitiveConversion::configure(
 }
 
 
-// Specialized for CSC
+// _____________________________________________________________________________
+// Specialized process() for CSC
 template<>
 void PrimitiveConversion::process(
     CSCTag tag,
@@ -78,7 +78,9 @@ void PrimitiveConversion::process(
   }
 }
 
-// Specialized for RPC
+
+// _____________________________________________________________________________
+// Specialized process() for RPC
 template<>
 void PrimitiveConversion::process(
     RPCTag tag,
@@ -110,9 +112,22 @@ void PrimitiveConversion::process(
   }
 }
 
-const SectorProcessorLUT& PrimitiveConversion::lut() const {
-  return *lut_;
+
+// _____________________________________________________________________________
+// Specialized process() for GEM
+template<>
+void PrimitiveConversion::process(
+    GEMTag tag,
+    const std::map<int, TriggerPrimitiveCollection>& selected_gem_map,
+    EMTFHitCollection& conv_hits
+) const {
+  std::map<int, TriggerPrimitiveCollection>::const_iterator map_tp_it  = selected_gem_map.begin();
+  std::map<int, TriggerPrimitiveCollection>::const_iterator map_tp_end = selected_gem_map.end();
+
+  for (; map_tp_it != map_tp_end; ++map_tp_it) {
+  }
 }
+
 
 // _____________________________________________________________________________
 // CSC functions
@@ -553,6 +568,7 @@ void PrimitiveConversion::convert_csc_details(EMTFHit& conv_hit) const {
   conv_hit.set_eta      ( emtf::calc_eta_from_theta_deg(conv_hit.Theta(), conv_hit.Endcap()) );
 }
 
+
 // _____________________________________________________________________________
 // RPC functions
 void PrimitiveConversion::convert_rpc(
@@ -649,6 +665,7 @@ void PrimitiveConversion::convert_rpc(
 
   convert_rpc_details(conv_hit);
 }
+
 
 void PrimitiveConversion::convert_rpc_details(EMTFHit& conv_hit) const {
   const bool is_neighbor = conv_hit.Neighbor();

--- a/L1TMuonEndCap/src/SectorProcessor.cc
+++ b/L1TMuonEndCap/src/SectorProcessor.cc
@@ -20,7 +20,7 @@ void SectorProcessor::configure(
     const SectorProcessorLUT* lut,
     const PtAssignmentEngine* pt_assign_engine,
     int verbose, int endcap, int sector,
-    int minBX, int maxBX, int bxWindow, int bxShiftCSC, int bxShiftRPC,
+    int minBX, int maxBX, int bxWindow, int bxShiftCSC, int bxShiftRPC, int bxShiftGEM,
     const std::vector<int>& zoneBoundaries, int zoneOverlap, int zoneOverlapRPC,
     bool includeNeighbor, bool duplicateTheta, bool fixZonePhi, bool useNewZones, bool fixME11Edges,
     const std::vector<std::string>& pattDefinitions, const std::vector<std::string>& symPattDefinitions, bool useSymPatterns,
@@ -50,6 +50,7 @@ void SectorProcessor::configure(
   bxWindow_    = bxWindow;
   bxShiftCSC_  = bxShiftCSC;
   bxShiftRPC_  = bxShiftRPC;
+  bxShiftGEM_  = bxShiftGEM;
 
   zoneBoundaries_     = zoneBoundaries;
   zoneOverlap_        = zoneOverlap;
@@ -98,6 +99,9 @@ void SectorProcessor::process(
   // Map of pattern detector --> lifetime, tracked across BXs
   std::map<pattern_ref_t, int> patt_lifetime_map;
 
+  // ___________________________________________________________________________
+  // Run each sector processor for every BX, taking into account the BX window
+
   int delayBX = bxWindow_ - 1;
 
   for (int bx = minBX_; bx <= maxBX_ + delayBX; ++bx) {
@@ -143,7 +147,7 @@ void SectorProcessor::process_single_bx(
   PrimitiveSelection prim_sel;
   prim_sel.configure(
       verbose_, endcap_, sector_, bx,
-      bxShiftCSC_, bxShiftRPC_,
+      bxShiftCSC_, bxShiftRPC_, bxShiftGEM_,
       includeNeighbor_, duplicateTheta_,
       bugME11Dupes_
   );
@@ -152,7 +156,7 @@ void SectorProcessor::process_single_bx(
   prim_conv.configure(
       tp_geom_, lut_,
       verbose_, endcap_, sector_, bx,
-      bxShiftCSC_, bxShiftRPC_,
+      bxShiftCSC_, bxShiftRPC_, bxShiftGEM_,
       zoneBoundaries_, zoneOverlap_, zoneOverlapRPC_,
       duplicateTheta_, fixZonePhi_, useNewZones_, fixME11Edges_,
       bugME11Dupes_
@@ -200,29 +204,33 @@ void SectorProcessor::process_single_bx(
 
   std::map<int, TriggerPrimitiveCollection> selected_csc_map;
   std::map<int, TriggerPrimitiveCollection> selected_rpc_map;
+  std::map<int, TriggerPrimitiveCollection> selected_gem_map;
 
-  EMTFHitCollection conv_hits;
+  EMTFHitCollection conv_hits;  // "converted" hits converted by primitive converter
 
   zone_array<EMTFRoadCollection> zone_roads;  // each zone has its road collection
 
   zone_array<EMTFTrackCollection> zone_tracks;  // each zone has its track collection
 
-  EMTFTrackCollection best_tracks;
+  EMTFTrackCollection best_tracks;  // "best" tracks selected from all the zones
 
   // ___________________________________________________________________________
   // Process
 
   // Select muon primitives that belong to this sector and this BX.
   // Put them into maps with an index that roughly corresponds to
-  // each input link. From src/PrimitiveSelection.cc.
+  // each input link.
+  // From src/PrimitiveSelection.cc
   prim_sel.process(CSCTag(), muon_primitives, selected_csc_map);
   prim_sel.process(RPCTag(), muon_primitives, selected_rpc_map);
+  prim_sel.process(GEMTag(), muon_primitives, selected_gem_map);
 
-  // Convert trigger primitives into "converted hits"
+  // Convert trigger primitives into "converted" hits
   // A converted hit consists of integer representations of phi, theta, and zones
   // From src/PrimitiveConversion.cc
   prim_conv.process(CSCTag(), selected_csc_map, conv_hits);
   prim_conv.process(RPCTag(), selected_rpc_map, conv_hits);
+  prim_conv.process(GEMTag(), selected_gem_map, conv_hits);
   extended_conv_hits.push_back(conv_hits);
 
   // Detect patterns in all zones, find 3 best roads in each zone
@@ -238,11 +246,11 @@ void SectorProcessor::process_single_bx(
   angle_calc.process(zone_tracks);
   extended_best_track_cands.insert(extended_best_track_cands.begin(), zone_tracks.begin(), zone_tracks.end());  // push_front
 
-  // Identify 3 best tracks
+  // Select 3 "best" tracks from all the zones
   // From src/BestTrackSelection.cc
   btrack_sel.process(extended_best_track_cands, best_tracks);
 
-  // Construct pT address, assign pT
+  // Construct pT address, assign pT, calculate other GMT quantities
   // From src/PtAssignment.cc
   pt_assign.process(best_tracks);
 

--- a/L1TMuonEndCap/src/SectorProcessor.cc
+++ b/L1TMuonEndCap/src/SectorProcessor.cc
@@ -205,6 +205,7 @@ void SectorProcessor::process_single_bx(
   std::map<int, TriggerPrimitiveCollection> selected_csc_map;
   std::map<int, TriggerPrimitiveCollection> selected_rpc_map;
   std::map<int, TriggerPrimitiveCollection> selected_gem_map;
+  std::map<int, TriggerPrimitiveCollection> selected_prim_map;
 
   EMTFHitCollection conv_hits;  // "converted" hits converted by primitive converter
 
@@ -224,13 +225,12 @@ void SectorProcessor::process_single_bx(
   prim_sel.process(CSCTag(), muon_primitives, selected_csc_map);
   prim_sel.process(RPCTag(), muon_primitives, selected_rpc_map);
   prim_sel.process(GEMTag(), muon_primitives, selected_gem_map);
+  prim_sel.merge(selected_csc_map, selected_rpc_map, selected_gem_map, selected_prim_map);
 
   // Convert trigger primitives into "converted" hits
   // A converted hit consists of integer representations of phi, theta, and zones
   // From src/PrimitiveConversion.cc
-  prim_conv.process(CSCTag(), selected_csc_map, conv_hits);
-  prim_conv.process(RPCTag(), selected_rpc_map, conv_hits);
-  prim_conv.process(GEMTag(), selected_gem_map, conv_hits);
+  prim_conv.process(selected_prim_map, conv_hits);
   extended_conv_hits.push_back(conv_hits);
 
   // Detect patterns in all zones, find 3 best roads in each zone

--- a/L1TMuonEndCap/test/tools/make_anglelut_phasetwogeom.py
+++ b/L1TMuonEndCap/test/tools/make_anglelut_phasetwogeom.py
@@ -1,0 +1,34 @@
+#
+# This cfg calls MakeAngleLUT which is obsolete and completely unused.
+#
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("Whatever")
+
+process.load('Configuration.Geometry.GeometryExtended2023D4Reco_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '90X_upgrade2023_realistic_v9', '')
+print "Using GlobalTag: %s" % process.GlobalTag.globaltag.value()
+
+# Fake alignment is/should be ideal geometry
+# ==========================================
+process.load("Alignment.CommonAlignmentProducer.FakeAlignmentSource_cfi")
+process.preferFakeAlign = cms.ESPrefer("FakeAlignmentSource")
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
+
+process.analyzer1 = cms.EDAnalyzer("MakeAngleLUT",
+    # Verbosity level
+    verbosity = cms.untracked.int32(1),
+
+    # Output file
+    outfile = cms.string("angle.root"),
+)
+
+process.path1 = cms.Path(process.analyzer1)


### PR DESCRIPTION
This PR brings GEM hits into the EMTF algorithm. It is still a work-in-progress. It is based upon Sven Dildick's branch dildick:from-CMSSW_9_1_0_pre2-add-GEM-EMTF . The inclusion of GEM hits mimics the inclusion of RPC hits, which is sub-optimal for various reasons. But this is just a very preliminary, first version that is pending a lot more validation/improvements.

Parts of the codes dealing with RPC have been updated to reduce some code duplication.