### PR TITLE
Move to CMSSW_10_6_0

### DIFF
--- a/L1TMuonEndCap/test/RunTrackFinder_MC.py
+++ b/L1TMuonEndCap/test/RunTrackFinder_MC.py
@@ -8,9 +8,9 @@ import subprocess
 
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('reL1T', eras.Run2_2016)
+from Configuration.Eras.Era_Run2_2016_cff import Run2_2016
+process = cms.Process('reL1T', Run2_2016)
 
 ## Import standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/L1TMuonEndCap/test/RunTrackFinder_data.py
+++ b/L1TMuonEndCap/test/RunTrackFinder_data.py
@@ -6,7 +6,6 @@ import os
 import sys
 import commands
 import subprocess
-from Configuration.StandardSequences.Eras import eras
 
 process = cms.Process('L1TMuonEmulation')
 

--- a/L1TMuonEndCap/test/UnpackTrackFinder_data_2016_10_04.py
+++ b/L1TMuonEndCap/test/UnpackTrackFinder_data_2016_10_04.py
@@ -5,7 +5,6 @@ import os
 import sys
 import commands
 import subprocess
-from Configuration.StandardSequences.Eras import eras
 
 process = cms.Process('L1TMuonEmulation')
 

--- a/L1TMuonEndCap/test/tools/make_coordlut_data.py
+++ b/L1TMuonEndCap/test/tools/make_coordlut_data.py
@@ -1,9 +1,9 @@
 from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 
-from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process("Whatever",eras.Run2_2018)
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+process = cms.Process("Whatever",Run2_2018)
 
 process.load('Configuration.StandardSequences.GeometryRecoDB_cff')  # load from DB
 process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')


### PR DESCRIPTION
This PR brings me from CMSSW_10_4_0 to CMSSW_10_6_0 (official-cmssw).

The base l1t-integration-CMSSW_10_6_0 is branched from commit 3ef1323716a , which has diverged from the standard CMSSW.

The original commits are extracted and applied as follows:

```
## Extract
git format-patch -1 b5e510e6d95 . --stdout > commit-b5e510e6d95.patch
git format-patch -1 3f1e190d840 . --stdout > commit-3f1e190d840.patch

## Apply
git am -p2 $ORI/commit-b5e510e6d95.patch
git am -p2 $ORI/commit-3f1e190d840.patch
```

The remote HEAD for L1Trigger/L1TMuonEndCap at the time of this PR is https://github.com/cms-sw/cmssw/tree/14d40ab34218f12a21ca27f2beba3b86d9043aee/L1Trigger/L1TMuonEndCap